### PR TITLE
Make components Vue 3 compliant

### DIFF
--- a/src/BIMDataComponents/BIMDataCheckbox/BIMDataCheckbox.vue
+++ b/src/BIMDataComponents/BIMDataCheckbox/BIMDataCheckbox.vue
@@ -16,18 +16,18 @@ export default {
   name: "BIMDataCheckbox",
   inheritAttrs: false,
   model: {
-    prop: "state",
-    event: "change",
+    prop: "modelValue",
+    event: "update:modelValue",
   },
   props: {
     text: {
       type: String,
       default: null,
     },
-    state: {
+    modelValue: {
       type: Boolean,
-      validator(state) {
-        return state === null || typeof state === "boolean";
+      validator(value) {
+        return value === null || typeof value === "boolean";
       },
     },
     disabled: {
@@ -36,20 +36,20 @@ export default {
     },
   },
   emits: [
-    'change'
+    "update:modelValue"
   ],
   computed: {
     indeterminate() {
-      return this.state === null;
+      return this.modelValue === null;
     },
     checked() {
-      return this.state === true || this.indeterminate;
+      return this.modelValue === true || this.indeterminate;
     },
   },
   methods: {
     onClick() {
       if (!this.disabled) {
-        this.$emit("change", this.checked ? false : true);
+        this.$emit("update:modelValue", this.checked ? false : true);
       }
     },
   },

--- a/src/BIMDataComponents/BIMDataCheckbox/__tests__/BIMDataCheckbox.test.js
+++ b/src/BIMDataComponents/BIMDataCheckbox/__tests__/BIMDataCheckbox.test.js
@@ -5,7 +5,7 @@ describe("BIMDataCheckbox", () => {
   it("should render component and match snapshot", () => {
     const wrapper = shallowMount(BIMDataCheckbox, {
       propsData: {
-        state: false,
+        modelValue: false,
       },
     });
     expect(wrapper.html()).toMatchSnapshot();
@@ -14,7 +14,7 @@ describe("BIMDataCheckbox", () => {
   it("should render component with text and match snapshot", () => {
     const wrapper = shallowMount(BIMDataCheckbox, {
       propsData: {
-        state: false,
+        modelValue: false,
         text: "text checkbox",
       },
     });
@@ -24,7 +24,7 @@ describe("BIMDataCheckbox", () => {
   it("should contain 'bimdata-checkbox' class when state false", () => {
     const wrapper = shallowMount(BIMDataCheckbox, {
       propsData: {
-        state: false,
+        modelValue: false,
       },
     });
 
@@ -34,7 +34,7 @@ describe("BIMDataCheckbox", () => {
   it("should contain 'bimdata-chekbox' and 'checked' class when state true", () => {
     const wrapper = shallowMount(BIMDataCheckbox, {
       propsData: {
-        state: true,
+        modelValue: true,
       },
     });
 
@@ -44,7 +44,7 @@ describe("BIMDataCheckbox", () => {
   it("should contain 'bimdata-chekbox', 'checked' and 'indeterminate' class when state null", () => {
     const wrapper = shallowMount(BIMDataCheckbox, {
       propsData: {
-        state: null,
+        modelValue: null,
       },
     });
 
@@ -55,10 +55,10 @@ describe("BIMDataCheckbox", () => {
     const onClick = jest.fn();
     const wrapper = shallowMount(BIMDataCheckbox, {
       propsData: {
-        state: false,
+        modelValue: false,
       },
       listeners: {
-        change: onClick,
+        'update:modelValue': onClick,
       },
     });
     wrapper.trigger("click");
@@ -69,10 +69,10 @@ describe("BIMDataCheckbox", () => {
     const onClick = jest.fn();
     const wrapper = shallowMount(BIMDataCheckbox, {
       propsData: {
-        state: true,
+        modelValue: true,
       },
       listeners: {
-        change: onClick,
+        'update:modelValue': onClick,
       },
     });
     wrapper.trigger("click");
@@ -83,10 +83,10 @@ describe("BIMDataCheckbox", () => {
     const onClick = jest.fn();
     const wrapper = shallowMount(BIMDataCheckbox, {
       propsData: {
-        state: null,
+        modelValue: null,
       },
       listeners: {
-        change: onClick,
+        'update:modelValue': onClick,
       },
     });
     wrapper.trigger("click");

--- a/src/BIMDataComponents/BIMDataInput/BIMDataInput.vue
+++ b/src/BIMDataComponents/BIMDataInput/BIMDataInput.vue
@@ -1,14 +1,14 @@
 <template>
   <div
     class="bimdata-input"
-    :class="{ error, success, disabled, loading, 'not-empty': !!text }"
+    :class="{ error, success, disabled, loading, 'not-empty': !!modelValue }"
   >
     <input
       ref="input"
       :id="`bimdata-input-${_uid}`"
-      @input="$emit('input', $event.currentTarget.value)"
+      @input="$emit('update:modelValue', $event.currentTarget.value)"
       :disabled="disabled"
-      :value="text"
+      :value="modelValue"
       @focus="$event.target.select()"
       v-bind="$attrs"
     />
@@ -25,11 +25,11 @@
 <script>
 export default {
   model: {
-    prop: "text",
-    event: "input",
+    prop: "modelValue",
+    event: "update:modelValue",
   },
   props: {
-    text: {
+    modelValue: {
       type: [String, Number, Boolean],
       default: "",
     },
@@ -63,7 +63,7 @@ export default {
     },
   },
   emits: [
-    'input'
+    "update:modelValue"
   ],
   created() {
     this.$watch(

--- a/src/BIMDataComponents/BIMDataInput/__tests__/BIMDataInput.test.js
+++ b/src/BIMDataComponents/BIMDataInput/__tests__/BIMDataInput.test.js
@@ -57,7 +57,7 @@ describe("BIMDataInput", () => {
   it("should render component with 'not empty' class and match snapshot", () => {
     const wrapper = shallowMount(BIMDataInput, {
       propsData: {
-        text: "text message",
+        modelValue: "text message",
       },
     });
     expect(wrapper.classes("not-empty")).toBe(true);
@@ -68,7 +68,7 @@ describe("BIMDataInput", () => {
     const onInput = jest.fn();
     const wrapper = shallowMount(BIMDataInput, {
       listeners: {
-        input: onInput,
+        'update:modelValue': onInput,
       },
     });
     expect(wrapper.find("input").element.value).toBe("");
@@ -76,7 +76,7 @@ describe("BIMDataInput", () => {
     wrapper.find("input").setValue("x");
     expect(onInput).toHaveBeenCalledWith("x");
 
-    wrapper.setProps({ text: "message" });
+    wrapper.setProps({ modelValue: "message" });
     await wrapper.vm.$nextTick();
     expect(wrapper.find("input").element.value).toBe("message");
   });

--- a/src/BIMDataComponents/BIMDataPaginatedList/BIMDataPaginatedList.vue
+++ b/src/BIMDataComponents/BIMDataPaginatedList/BIMDataPaginatedList.vue
@@ -76,11 +76,12 @@ export default {
   },
   watch: {
     list: {
-      handler(list) {
-        if (list.length < this.perPage * (this.currentPage - 1) + 1) {
+      handler() {
+        if (this.list.length < this.perPage * (this.currentPage - 1) + 1) {
           this.currentPage = 1;
         }
       },
+      deep: true,
       immediate: true,
     },
   },

--- a/src/BIMDataComponents/BIMDataRadio/BIMDataRadio.vue
+++ b/src/BIMDataComponents/BIMDataRadio/BIMDataRadio.vue
@@ -3,7 +3,7 @@
     <input
       type="radio"
       @input="onInput"
-      :checked="selectedValue === value"
+      :checked="modelValue === value"
       :name="name"
       :id="id"
       :value="value"
@@ -16,7 +16,8 @@
 <script>
 export default {
   model: {
-    prop: "selectedValue",
+    prop: "modelValue",
+    event: "update:modelValue"
   },
   props: {
     text: {
@@ -31,18 +32,18 @@ export default {
       type: [String, Number],
     },
     value: {},
-    selectedValue: {},
+    modelValue: {},
     disabled: {
       type: Boolean,
       default: false,
     },
   },
   emits: [
-    'input'
+    "update:modelValue"
   ],
   methods: {
     onInput() {
-      this.$emit("input", this.value);
+      this.$emit("update:modelValue", this.value);
     },
   },
 };

--- a/src/BIMDataComponents/BIMDataSearch/BIMDataSearch.vue
+++ b/src/BIMDataComponents/BIMDataSearch/BIMDataSearch.vue
@@ -10,18 +10,18 @@
     </span>
     <input
       ref="input"
-      :value="value"
+      :value="modelValue"
       v-focus="autofocus"
       @focus="focused = true"
       @blur="focused = false"
-      @input="$emit('input', $event.target.value)"
+      @input="$emit('update:modelValue', $event.target.value)"
       :placeholder="placeholder"
       @keyup.enter="$emit('enter', $event.target.value)"
     />
     <BIMDataButton
       width="25px"
       @click="clickClear()"
-      v-if="clear && value !== ''"
+      v-if="clear && modelValue !== ''"
     >
       <BIMDataIcon name="close" size="xxs" />
     </BIMDataButton>
@@ -50,9 +50,8 @@ export default {
     clickaway,
   },
   props: {
-    value: {
+    modelValue: {
       type: String,
-      required: true,
     },
     placeholder: {
       type: String,
@@ -76,9 +75,9 @@ export default {
     },
   },
   emits: [
-    'input',
-    'enter',
-    'clear'
+    "update:modelValue",
+    "enter",
+    "clear"
   ],
   data() {
     return {
@@ -97,7 +96,7 @@ export default {
       this.$refs.input && this.$refs.input.blur();
     },
     clickClear() {
-      this.$emit("input", "");
+      this.$emit("update:modelValue", "");
       this.$emit("clear");
     },
   },

--- a/src/BIMDataComponents/BIMDataSelect/BIMDataSelect.vue
+++ b/src/BIMDataComponents/BIMDataSelect/BIMDataSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="bimdata-select"
-    :class="{ 'not-empty': value != null && value != value.length }"
+    :class="{ 'not-empty': modelValue != null && modelValue != modelValue.length }"
     :style="{ 'min-width': width }"
   >
     <div class="bimdata-select__content">
@@ -27,7 +27,7 @@
           v-for="(option, index) of options"
           :key="index"
           :class="{
-            selected: multi ? value.includes(option) : option === value,
+            selected: multi ? modelValue.includes(option) : option === modelValue,
             disabled: optionKey && option.disabled,
             'option-group': isOptionGroup(option),
           }"
@@ -39,7 +39,7 @@
           <template v-else>
             <BIMDataCheckbox
               v-if="multi"
-              :state="value.includes(option)"
+              :modelValue="modelValue.includes(option)"
               :disabled="optionKey && option.disabled"
             >
               {{ optionKey ? option && option[optionKey] : option }}
@@ -67,7 +67,8 @@ export default {
   },
   directives: { clickaway },
   model: {
-    event: "option-click",
+    prop: "modelValue",
+    event: "update:modelValue",
   },
   props: {
     optionKey: {
@@ -82,7 +83,7 @@ export default {
       type: Boolean,
       default: false,
     },
-    value: {
+    modelValue: {
       type: [String, Array, Object],
     },
     label: { type: String, default: null },
@@ -93,35 +94,35 @@ export default {
     },
   },
   emits: [
-    'option-click'
+    "update:modelValue"
   ],
   data() {
     return {
       displayOptions: false,
-      selectedOptions: this.value,
+      selectedOptions: this.modelValue,
     };
   },
   computed: {
     displayedValue() {
-      if (this.value === null || this.value === undefined) {
+      if (this.modelValue === null || this.modelValue === undefined) {
         return null;
       } else if (this.multi) {
-        return this.formatValue(this.value);
+        return this.formatValue(this.modelValue);
       } else {
-        return this.optionKey ? this.value[this.optionKey] : this.value;
+        return this.optionKey ? this.modelValue[this.optionKey] : this.modelValue;
       }
     },
   },
   watch: {
     multi() {
-      if (this.multi && !Array.isArray(this.value)) {
+      if (this.multi && !Array.isArray(this.modelValue)) {
         throw "value must be an array in multi mode.";
       }
       if (
         !this.multi &&
-        typeof this.value !== "string" &&
-        typeof this.value !== "number" &&
-        this.value !== null
+        typeof this.modelValue !== "string" &&
+        typeof this.modelValue !== "number" &&
+        this.modelValue !== null
       ) {
         throw "value must be a string or a number in non-multi mode.";
       }
@@ -144,23 +145,20 @@ export default {
     onOptionClick(option) {
       if (this.optionKey && (option.disabled || option.optionGroup)) return;
       if (this.multi) {
-        if (this.value.includes(option)) {
-          this.$emit(
-            "option-click",
-            this.value.filter(val => val !== option)
-          );
+        if (this.modelValue.includes(option)) {
+          this.$emit("update:modelValue", this.modelValue.filter(val => val !== option));
         } else {
-          const copy = Array.from(this.value);
+          const copy = Array.from(this.modelValue);
           copy.push(option);
-          this.$emit("option-click", copy);
+          this.$emit("update:modelValue", copy);
         }
       } else {
-        this.$emit("option-click", option);
+        this.$emit("update:modelValue", option);
         this.displayOptions = !this.displayOptions;
       }
     },
     onNullValueClick() {
-      this.$emit("option-click", null);
+      this.$emit("update:modelValue", null);
       this.displayOptions = !this.displayOptions;
     },
     away() {

--- a/src/BIMDataComponents/BIMDataTextarea/BIMDataTextarea.vue
+++ b/src/BIMDataComponents/BIMDataTextarea/BIMDataTextarea.vue
@@ -3,7 +3,7 @@
     class="bimdata-textarea"
     :class="{
       'not-empty':
-        (message !== null && message !== '') ||
+        (modelValue !== null && modelValue !== '') ||
         placeholder !== null, error, success
     }"
     :style="{ 'min-width': width, 'min-height': height }"
@@ -12,10 +12,10 @@
       v-focus="autofocus"
       :name="name"
       :id="name"
-      :value="message"
+      :value="modelValue"
       :placeholder="placeholder"
       :disabled="disabled"
-      @input="$emit('input', $event.currentTarget.value)"
+      @input="$emit('update:modelValue', $event.currentTarget.value)"
     />
     <label :for="name">{{ label }}</label>
     <span class="bar"></span>
@@ -36,15 +36,15 @@ export default {
     },
   },
   model: {
-    prop: "message",
-    event: "input",
+    prop: "modelValue",
+    event: "update:modelValue",
   },
   props: {
     name: {
       type: [String, Number],
       default: "",
     },
-    message: {
+    modelValue: {
       type: [String, Number],
       default: null,
     },
@@ -90,7 +90,7 @@ export default {
     },
   },
   emits: [
-    'input'
+    "update:modelValue"
   ],
   created() {
     this.$watch(

--- a/src/BIMDataComponents/BIMDataTextarea/__tests__/BIMDataTextarea.test.js
+++ b/src/BIMDataComponents/BIMDataTextarea/__tests__/BIMDataTextarea.test.js
@@ -22,10 +22,10 @@ describe("BIMDataTextarea", () => {
     const onInput = jest.fn();
     const wrapper = shallowMount(BIMDataTextarea, {
       propsData: {
-        message: null,
+        modelValue: null,
       },
       listeners: {
-        input: onInput,
+        'update:modelValue': onInput,
       },
     });
     expect(wrapper.find("textarea").element.value).toBe("");
@@ -33,7 +33,7 @@ describe("BIMDataTextarea", () => {
     wrapper.find("textarea").setValue("x");
     expect(onInput).toHaveBeenCalledWith("x");
 
-    wrapper.setProps({ message: "message" });
+    wrapper.setProps({ modelValue: "message" });
     await wrapper.vm.$nextTick();
     expect(wrapper.classes("not-empty")).toBe(true);
     expect(wrapper.find("textarea").element.value).toBe("message");

--- a/src/BIMDataComponents/BIMDataTextarea/__tests__/__snapshots__/BIMDataTextarea.test.js.snap
+++ b/src/BIMDataComponents/BIMDataTextarea/__tests__/__snapshots__/BIMDataTextarea.test.js.snap
@@ -1,15 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BIMDataTextarea should render a disabled component and match snapshot 1`] = `"<div class=\\"bimdata-textarea\\" style=\\"min-width: 150px; min-height: 32px;\\"><textarea name=\\"\\" id=\\"\\" disabled=\\"disabled\\"></textarea> <label for=\\"\\"></label> <span class=\\"bar\\"></span></div>"`;
+exports[`BIMDataTextarea should render a disabled component and match snapshot 1`] = `
+"<div class=\\"bimdata-textarea\\" style=\\"min-width: 150px; min-height: 32px;\\"><textarea name=\\"\\" id=\\"\\" disabled=\\"disabled\\"></textarea> <label for=\\"\\"></label> <span class=\\"bar\\"></span>
+  <!---->
+  <!---->
+</div>"
+`;
 
-exports[`BIMDataTextarea should render component and match snapshot 1`] = `"<div class=\\"bimdata-textarea\\" style=\\"min-width: 150px; min-height: 32px;\\"><textarea name=\\"\\" id=\\"\\"></textarea> <label for=\\"\\"></label> <span class=\\"bar\\"></span></div>"`;
+exports[`BIMDataTextarea should render component and match snapshot 1`] = `
+"<div class=\\"bimdata-textarea\\" style=\\"min-width: 150px; min-height: 32px;\\"><textarea name=\\"\\" id=\\"\\"></textarea> <label for=\\"\\"></label> <span class=\\"bar\\"></span>
+  <!---->
+  <!---->
+</div>"
+`;
 
-exports[`BIMDataTextarea should render component with a custom height and match snapshot 1`] = `"<div class=\\"bimdata-textarea\\" style=\\"min-width: 150px; min-height: 50px;\\"><textarea name=\\"\\" id=\\"\\"></textarea> <label for=\\"\\"></label> <span class=\\"bar\\"></span></div>"`;
+exports[`BIMDataTextarea should render component with a custom height and match snapshot 1`] = `
+"<div class=\\"bimdata-textarea\\" style=\\"min-width: 150px; min-height: 50px;\\"><textarea name=\\"\\" id=\\"\\"></textarea> <label for=\\"\\"></label> <span class=\\"bar\\"></span>
+  <!---->
+  <!---->
+</div>"
+`;
 
-exports[`BIMDataTextarea should render component with a custom width and match snapshot 1`] = `"<div class=\\"bimdata-textarea\\" style=\\"min-width: 50px; min-height: 32px;\\"><textarea name=\\"\\" id=\\"\\"></textarea> <label for=\\"\\"></label> <span class=\\"bar\\"></span></div>"`;
+exports[`BIMDataTextarea should render component with a custom width and match snapshot 1`] = `
+"<div class=\\"bimdata-textarea\\" style=\\"min-width: 50px; min-height: 32px;\\"><textarea name=\\"\\" id=\\"\\"></textarea> <label for=\\"\\"></label> <span class=\\"bar\\"></span>
+  <!---->
+  <!---->
+</div>"
+`;
 
-exports[`BIMDataTextarea should render component with custom label and match snapshot 1`] = `"<div class=\\"bimdata-textarea\\" style=\\"min-width: 150px; min-height: 32px;\\"><textarea name=\\"\\" id=\\"\\"></textarea> <label for=\\"\\">textarea label</label> <span class=\\"bar\\"></span></div>"`;
+exports[`BIMDataTextarea should render component with custom label and match snapshot 1`] = `
+"<div class=\\"bimdata-textarea\\" style=\\"min-width: 150px; min-height: 32px;\\"><textarea name=\\"\\" id=\\"\\"></textarea> <label for=\\"\\">textarea label</label> <span class=\\"bar\\"></span>
+  <!---->
+  <!---->
+</div>"
+`;
 
-exports[`BIMDataTextarea should render component with custom name, match with id and match snapshot 1`] = `"<div class=\\"bimdata-textarea\\" style=\\"min-width: 150px; min-height: 32px;\\"><textarea name=\\"placeholderName\\" id=\\"placeholderName\\"></textarea> <label for=\\"placeholderName\\"></label> <span class=\\"bar\\"></span></div>"`;
+exports[`BIMDataTextarea should render component with custom name, match with id and match snapshot 1`] = `
+"<div class=\\"bimdata-textarea\\" style=\\"min-width: 150px; min-height: 32px;\\"><textarea name=\\"placeholderName\\" id=\\"placeholderName\\"></textarea> <label for=\\"placeholderName\\"></label> <span class=\\"bar\\"></span>
+  <!---->
+  <!---->
+</div>"
+`;
 
-exports[`BIMDataTextarea should render component with custom placeholder, contains 'not-empty' class and match snapshot 1`] = `"<div class=\\"bimdata-textarea not-empty\\" style=\\"min-width: 150px; min-height: 32px;\\"><textarea name=\\"\\" id=\\"\\" placeholder=\\"textarea placeholder\\"></textarea> <label for=\\"\\"></label> <span class=\\"bar\\"></span></div>"`;
+exports[`BIMDataTextarea should render component with custom placeholder, contains 'not-empty' class and match snapshot 1`] = `
+"<div class=\\"bimdata-textarea not-empty\\" style=\\"min-width: 150px; min-height: 32px;\\"><textarea name=\\"\\" id=\\"\\" placeholder=\\"textarea placeholder\\"></textarea> <label for=\\"\\"></label> <span class=\\"bar\\"></span>
+  <!---->
+  <!---->
+</div>"
+`;

--- a/src/BIMDataComponents/BIMDataToggle/BIMDataToggle.vue
+++ b/src/BIMDataComponents/BIMDataToggle/BIMDataToggle.vue
@@ -1,7 +1,7 @@
 <template>
   <label
     :for="`bimdata-toggle-${_uid}`"
-    :class="{ active: value, disabled }"
+    :class="{ active: modelValue, disabled }"
     class="toggle__button"
   >
     <slot></slot>
@@ -23,21 +23,21 @@ export default {
       type: Boolean,
       default: false,
     },
-    value: {
+    modelValue: {
       type: Boolean,
       default: false,
     },
   },
   emits: [
-    'input'
+    "update:modelValue"
   ],
   computed: {
     checkedValue: {
       get() {
-        return this.value;
+        return this.modelValue;
       },
       set(newValue) {
-        this.$emit("input", newValue);
+        this.$emit("update:modelValue", newValue);
       },
     },
   },

--- a/src/BIMDataComponents/BIMDataTooltip/BIMDataTooltip.vue
+++ b/src/BIMDataComponents/BIMDataTooltip/BIMDataTooltip.vue
@@ -58,12 +58,18 @@ export default {
   mounted() {
     this.$options.resizeObserver = new ResizeObserver(this.onResize);
   },
+  unmounted() { // for Vue3 compatibility (destroyed => unmounted)
+    this.onDestroy();
+  },
   destroyed() {
-    if (this.$options.resizeObserver) {
-      this.$options.resizeObserver.disconnect();
-    }
+    this.onDestroy();
   },
   methods: {
+    onDestroy() {
+      if (this.$options.resizeObserver) {
+        this.$options.resizeObserver.disconnect();
+      }
+    },
     onResize(entries) {
       entries.forEach(entry => {
         this.width = entry.target.clientWidth;


### PR DESCRIPTION
## Résumé

Mise à jour des composants afin de les rendre compatibles avec une application en Vue 3.
Dans l'ensemble les composants ont été ajustés de façon rétro-compatible (même fonctionnement qu'auparavant).

(Voir https://v3.vuejs.org/guide/migration/introduction.html pour plus d'info).

## Breaking Changes

Cependant de potentiels **BREAKING CHANGES** ont été introduits, en particulier sur les composants de contrôle, en raison de l'adaptation de l'API `v-model` ([voir ici pour comprendre l'origine des modifications](https://v3.vuejs.org/guide/migration/v-model.html#overview)).

Voici ci-dessous la liste des composants concernés:
```
<BIMDataCheckbox /> :
  model:
    prop: state -> modelValue
    event: change -> update:modelValue

<BIMDataInput /> :
  model:
    prop: text -> modelValue
    event: input -> update:modelValue

<BIMDataRadio /> :
  model:
    prop: selectedValue -> modelValue
    event: input -> update:modelValue

<BIMDataSearch /> :
  model:
    prop: value -> modelValue
    event: input -> update:modelValue

<BIMDataSelect /> :
  model:
    prop: value -> modelValue
    event: option-click -> update:modelValue

<BIMDataTextarea /> :
  model:
    prop: message -> modelValue
    event: input -> update:modelValue

<BIMDataToggle /> :
  model:
    prop: value -> modelValue
    event: input -> update:modelValue
```

## Migration

Afin de prendre en charge les "breaking change" mentionnés ci-dessus il convient d'identifier, dans les applications utilisant le design system, les endroits où les éléments listés sont utilisés et vérifier que seule la directive `v-model` (sans argument) est utilisée pour "binder" leur valeur.
