### PR TITLE
Fix: input component uid

### DIFF
--- a/src/BIMDataComponents/BIMDataInput/BIMDataInput.vue
+++ b/src/BIMDataComponents/BIMDataInput/BIMDataInput.vue
@@ -5,7 +5,7 @@
   >
     <input
       ref="input"
-      :id="`bimdata-input-${_uid}`"
+      :id="`bimdata-input-${uuid}`"
       @input="$emit('update:modelValue', $event.currentTarget.value)"
       :disabled="disabled"
       :value="modelValue"
@@ -15,7 +15,7 @@
     <div class="bimdata-input__icon">
       <slot name="inputIcon"></slot>
     </div>
-    <label :for="`bimdata-input-${_uid}`">{{ placeholder }}</label>
+    <label :for="`bimdata-input-${uuid}`">{{ placeholder }}</label>
     <span class="bar"></span>
     <span v-if="error" class="error">{{ errorMessage }}</span>
     <span v-if="success" class="success">{{ successMessage }}</span>
@@ -23,6 +23,8 @@
 </template>
 
 <script>
+let uuid = 0;
+
 export default {
   model: {
     prop: "modelValue",
@@ -65,6 +67,10 @@ export default {
   emits: [
     "update:modelValue"
   ],
+  beforeCreate() {
+    this.uuid = uuid.toString();
+    uuid += 1;
+  },
   created() {
     this.$watch(
       () => this.success && this.error,

--- a/src/BIMDataComponents/BIMDataToggle/BIMDataToggle.vue
+++ b/src/BIMDataComponents/BIMDataToggle/BIMDataToggle.vue
@@ -1,6 +1,6 @@
 <template>
   <label
-    :for="`bimdata-toggle-${_uid}`"
+    :for="`bimdata-toggle-${uuid}`"
     :class="{ active: modelValue, disabled }"
     class="toggle__button"
   >
@@ -8,7 +8,7 @@
     <input
       type="checkbox"
       :disabled="disabled"
-      :id="`bimdata-toggle-${_uid}`"
+      :id="`bimdata-toggle-${uuid}`"
       v-model="checkedValue"
     />
     <span class="toggle__switch"></span>
@@ -17,6 +17,8 @@
 </template>
 
 <script>
+let uuid = 0;
+
 export default {
   model: {
     prop: "modelValue",
@@ -42,6 +44,10 @@ export default {
         this.$emit("update:modelValue", newValue);
       },
     },
+  },
+  beforeCreate() {
+    this.uuid = uuid.toString();
+    uuid += 1;
   },
 };
 </script>


### PR DESCRIPTION
Modification des composants `<BIMDataInput />` et `<BIMDataToggle />` pour en retirer l'utilisation de la propriété `_uid` dans le template.

Voir cette issue pour plus d'information: https://github.com/vuejs/vue/issues/5886

En aprticulier ce commentaire (de Evan You): https://github.com/vuejs/vue/issues/5886#issuecomment-308625735

Ainsi que celui-ci, dont je me suis largement inspiré pour implémenter la correction: https://github.com/vuejs/vue/issues/5886#issuecomment-308647738
