### PR TITLE
Update Tabs component

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -73,6 +73,7 @@ function getSingleComponentConfigurations() {
     "BIMDataSelect",
     "BIMDataSpinner",
     "BIMDataTable",
+    "BIMDataTabs",
     "BIMDataTextarea",
     "BIMDataToggle",
     "BIMDataTooltip",

--- a/src/BIMDataComponents/BIMDataTabs/BIMDataTabs.vue
+++ b/src/BIMDataComponents/BIMDataTabs/BIMDataTabs.vue
@@ -14,7 +14,7 @@
     </BIMDataButton>
     <ul
       ref="container"
-      class="bimdata-tabs__content"
+      class="bimdata-tabs__container"
       :style="{
         width: containerWidth,
         minHeight: containerHeight,
@@ -23,9 +23,8 @@
       <li
         v-for="tab of tabs"
         :key="tab.id"
-        ref="tab"
-        class="bimdata-tabs__content__element"
-        :class="{ active: tab === activeTab }"
+        class="bimdata-tabs__container__tab"
+        :class="{ active: tab.id === activeTab.id }"
         :style="{ minWidth: tabWidth }"
         @click="onTabClick(tab)"
       >
@@ -77,7 +76,7 @@ export default {
     return {
       scrollValues: [],
       displayIndex: 0,
-      activeTab: "",
+      activeTab: {},
     };
   },
   computed: {
@@ -140,22 +139,30 @@ export default {
       if (typeof value === "number" && value >= 0 && value < this.tabs.length) {
         this.activeTab = this.tabs[value];
         this.$emit("tab-selected", this.activeTab);
-      } else if (this.tabs.includes(value)) {
-        this.activeTab = value;
-        this.$emit("tab-selected", this.activeTab);
+      } else {
+        const tab = this.tabs.find(t => t.id === value);
+        if (tab) {
+          this.activeTab = tab;
+          this.$emit("tab-selected", this.activeTab);
+        }
       }
     },
     _setScrollValues() {
       this.displayIndex = 0;
-      let tw = this.$refs.tab[0].offsetWidth;
-      let cw = this.$refs.container.offsetWidth;
-      if (this.tabs.length * tw > cw) {
-        cw -= 64; // Take buttons size into account
-        this.scrollValues = [0].concat(
-          this.tabs.map((_, i) => (i + 1) * tw - cw).filter(v => v > 0)
-        );
-      } else {
-        this.scrollValues = [];
+      if (this.tabs.length > 0) {
+        let cw = this.$refs.container.offsetWidth;
+        let tw = this.$refs.container.querySelector(
+          ".bimdata-tabs__container__tab"
+        ).offsetWidth;
+
+        if (this.tabs.length * tw > cw) {
+          cw -= 64; // Take buttons size into account
+          this.scrollValues = [0].concat(
+            this.tabs.map((_, i) => (i + 1) * tw - cw).filter(v => v > 0)
+          );
+        } else {
+          this.scrollValues = [];
+        }
       }
     },
   },

--- a/src/BIMDataComponents/BIMDataTabs/BIMDataTabs.vue
+++ b/src/BIMDataComponents/BIMDataTabs/BIMDataTabs.vue
@@ -43,8 +43,8 @@
 </template>
 
 <script>
-import BIMDataButton from "../BIMDataButton/BIMDataButton";
-import BIMDataIcon from "../BIMDataIcon/BIMDataIcon";
+import BIMDataButton from "../BIMDataButton/BIMDataButton.vue";
+import BIMDataIcon from "../BIMDataIcon/BIMDataIcon.vue";
 
 export default {
   components: {

--- a/src/BIMDataComponents/BIMDataTabs/BIMDataTabs.vue
+++ b/src/BIMDataComponents/BIMDataTabs/BIMDataTabs.vue
@@ -22,14 +22,14 @@
     >
       <li
         v-for="tab of tabs"
-        :key="tab"
+        :key="tab.id"
         ref="tab"
         class="bimdata-tabs__content__element"
         :class="{ active: tab === activeTab }"
         :style="{ minWidth: tabWidth }"
         @click="onTabClick(tab)"
       >
-        {{ tab }}
+        {{ tab.label }}
       </li>
     </ul>
     <BIMDataButton

--- a/src/BIMDataComponents/BIMDataTabs/_BIMDataTabs.scss
+++ b/src/BIMDataComponents/BIMDataTabs/_BIMDataTabs.scss
@@ -28,7 +28,6 @@
       align-items: center;
       padding: 0 $spacing-unit / 2;
       text-align: center;
-      font-size: calculateEm(11px);
       color: $color-tertiary-darkest;
       cursor: pointer;
 

--- a/src/BIMDataComponents/BIMDataTabs/_BIMDataTabs.scss
+++ b/src/BIMDataComponents/BIMDataTabs/_BIMDataTabs.scss
@@ -12,7 +12,7 @@
     }
   }
 
-  &__content {
+  &__container {
     position: relative;
     display: flex;
     padding: 0;
@@ -20,7 +20,7 @@
     overflow: hidden;
     scroll-behavior: smooth;
 
-    &__element {
+    &__tab {
       box-sizing: border-box;
       position: relative;
       display: flex;

--- a/src/web/views/Components/Tabs/Tabs.vue
+++ b/src/web/views/Components/Tabs/Tabs.vue
@@ -90,10 +90,10 @@ export default {
         ["Props", "Type", "Required", "Default value", "Description"],
         [
           "tabs",
-          "Array<String>",
+          "Array<{ id: String, label: String }>",
           "true",
           "",
-          "The list of tab items (i.e. tab names)",
+          "The list of tab items (i.e. tabs id and label)",
         ],
         [
           "width",
@@ -144,7 +144,10 @@ export default {
   },
   computed: {
     tabs() {
-      return [...Array(+this.tabNumber).keys()].map(i => `Tab ${i + 1}`);
+      return [...Array(+this.tabNumber).keys()].map(i => ({
+        id: i,
+        label: `Tab ${i + 1}`,
+      }));
     },
   },
 };


### PR DESCRIPTION
Use an array of tab items (i.e. `{ id: String, label: String }`) for `tabs` prop instead of simple strings.

This allows to decouple tab identification from its displayed text (that can be internationalized and/or duplicated).

Also added Tabs component to `rollup.config.js`.

Take this breaking change into account for Vue 3 compatibility: https://v3.vuejs.org/guide/migration/array-refs.html

Commits:
 - feat(tabs): change tabs prop to accept an array of tab ids and labels
 - fix(build): add Tabs component to rollup build config
 - fix(tabs): remove the use of on v-for Array for vue3 compatibility