### PR TITLE
[BC] change of use of the icon component

### DIFF
--- a/src/BIMDataComponents/BIMDataIcon/BIMDataIcon.vue
+++ b/src/BIMDataComponents/BIMDataIcon/BIMDataIcon.vue
@@ -1,11 +1,13 @@
 <template>
   <svg
-    :fill="color"
+    :fill="fillColor"
     width="100%"
     preserveAspectRatio="xMidYMid meet"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"
     :style="style"
+    :color="color"
+    :class="classes"
   >
     <component :is="`bimdata-${name}`" />
   </svg>
@@ -13,6 +15,8 @@
 
 <script>
 import icons from "./BIMDataLibraryIcons/index.js";
+
+import iconsColors from "../../assets/iconsColors.js";
 
 const sizeToPixel = {
   xxxs: 10,
@@ -41,7 +45,20 @@ export default {
     },
     color: {
       type: String,
+      default: "default",
+      validator: color => iconsColors.includes(color),
+    },
+    fillColor: {
+      type: String,
       default: "currentColor",
+    },
+    fill: {
+      type: Boolean,
+      default: false,
+    },
+    stroke: {
+      type: Boolean,
+      default: false,
     },
     size: {
       type: String,
@@ -75,6 +92,12 @@ export default {
         };
       }
     },
+    classes() {
+      return {
+        [`icon-fill--${this.color}`]: this.fill && this.color,
+        [`icon-stroke--${this.color}`]: this.stroke && this.color,
+      };
+    },
   },
   methods: {
     getPixelSize() {
@@ -96,4 +119,5 @@ function formatIconComponentsNames(icons = {}) {
 <style lang="scss">
 // import BIMDATA VARIABLES
 @import "../../assets/scss/_BIMDataVariables.scss";
+@import "./_BIMDataIcon.scss";
 </style>

--- a/src/BIMDataComponents/BIMDataIcon/_BIMDataIcon.scss
+++ b/src/BIMDataComponents/BIMDataIcon/_BIMDataIcon.scss
@@ -1,0 +1,91 @@
+.icon {
+  &-fill {
+    &--black {
+      fill: $color-black;
+    }
+    &--default {
+      fill: currentColor;
+    }
+    &--disabled {
+      fill: $color-disabled;
+    }
+    &--high {
+      fill: $color-high;
+    }
+    &--neutral {
+      fill: $color-neutral;
+    }
+    &--primary {
+      fill: $color-primary;
+    }
+    &--secondary {
+      fill: $color-secondary;
+    }
+    &--success {
+      fill: $color-success;
+    }
+    &--tertiary {
+      fill: $color-tertiary;
+    }
+    &--tertiary-dark {
+      fill: $color-tertiary-dark;
+    }
+    &--tertiary-darkest {
+      fill: $color-tertiary-darkest;
+    }
+    &--tertiary-lightest {
+      fill: $color-tertiary-lightest;
+    }
+    &--warning {
+      fill: $color-warning;
+    }
+    &--white {
+      fill: $color-white;
+    }
+  }
+  &-stroke {
+    fill: transparent;
+    &--black {
+      stroke: $color-black;
+    }
+    &--default {
+      stroke: currentColor;
+    }
+    &--disabled {
+      stroke: $color-disabled;
+    }
+    &--high {
+      stroke: $color-high;
+    }
+    &--neutral {
+      stroke: $color-neutral;
+    }
+    &--primary {
+      stroke: $color-primary;
+    }
+    &--secondary {
+      stroke: $color-secondary;
+    }
+    &--success {
+      stroke: $color-success;
+    }
+    &--tertiary {
+      stroke: $color-tertiary;
+    }
+    &--tertiary-dark {
+      stroke: $color-tertiary-dark;
+    }
+    &--tertiary-darkest {
+      stroke: $color-tertiary-darkest;
+    }
+    &--tertiary-lightest {
+      stroke: $color-tertiary-lightest;
+    }
+    &--warning {
+      stroke: $color-warning;
+    }
+    &--white {
+      stroke: $color-white;
+    }
+  }
+}

--- a/src/assets/colors.js
+++ b/src/assets/colors.js
@@ -2,6 +2,6 @@ export default Object.freeze([
   "default",
   "primary",
   "secondary",
-  "tertiary-darkest",
   "high",
+  "tertiary-darkest",
 ]);

--- a/src/assets/iconsColors.js
+++ b/src/assets/iconsColors.js
@@ -1,0 +1,16 @@
+export default Object.freeze([
+  "black",
+  "default",
+  "disabled",
+  "high",
+  "neutral",
+  "primary",
+  "secondary",
+  "success",
+  "tertiary",
+  "tertiary-dark",
+  "tertiary-darkest",
+  "tertiary-lightest",
+  "warning",
+  "white",
+]);

--- a/src/web/views/Components/Icons/Icons.vue
+++ b/src/web/views/Components/Icons/Icons.vue
@@ -32,7 +32,7 @@
               <BIMDataIcon
                 :name="icon"
                 :size="selectedIconOptionssize"
-                :class="selectedIconOptionsclass"
+                :class="getOverviewIconClasses()"
                 :rotate="Number(rotationDeg)"
               />
               <p>{{ icon }}</p>
@@ -73,9 +73,9 @@
           <pre>
             &lt;BIMDataIcon name="{{ activeIcon }}" {{
               getIconOptionsSize()
-            }} class="{{ selectedIconOptionsclass }}" {{
-              getRotateDegree()
-            }}/&gt;
+            }} {{ selectedIconOptionstypes }} color="{{
+              selectedIconOptionsvalues
+            }}" {{ getRotateDegree() }}/&gt;
           </pre>
         </template>
       </ComponentCode>
@@ -112,6 +112,8 @@ import BIMDataTable from "../../../../../src/BIMDataComponents/BIMDataTable/BIMD
 import highlight from "../../../../BIMDataDirectives/highlight.js";
 import copy from "../../../../BIMDataDirectives/copy.js";
 
+import iconsColors from "../../../../assets/iconsColors.js";
+
 export default {
   components: {
     ComponentCode,
@@ -128,39 +130,14 @@ export default {
       size: "m",
       icons,
       filter: "",
-      selectedIconOptionsclass: "fill-primary",
+      selectedIconOptionstypes: "fill",
+      selectedIconOptionsvalues: "default",
       selectedIconOptionssize: "s",
       checkboxIconRotate: false,
       activeIcon: "addFile",
       iconOptions: {
-        class: [
-          "fill-primary",
-          "fill-secondary",
-          "fill-tertiary",
-          "fill-tertiary-lightest",
-          "fill-tertiary-dark",
-          "fill-tertiary-darkest",
-          "fill-white",
-          "fill-black",
-          "fill-neutral",
-          "fill-success",
-          "fill-disabled",
-          "fill-warning",
-          "fill-high",
-          "stroke-primary",
-          "stroke-secondary",
-          "stroke-tertiary",
-          "stroke-tertiary-lightest",
-          "stroke-tertiary-dark",
-          "stroke-tertiary-darkest",
-          "stroke-white",
-          "stroke-black",
-          "stroke-neutral",
-          "stroke-success",
-          "stroke-disabled",
-          "stroke-warning",
-          "stroke-high",
-        ],
+        types: ["fill", "stroke"],
+        values: iconsColors,
         size: ["xxxs", "xxs", "xs", "s", "m", "l", "xl", "xxl", "xxxl"],
       },
       propsData: [
@@ -173,28 +150,12 @@ export default {
           "Examples",
         ],
         [
-          "name",
-          "String",
-          "true",
-          "",
-          "Use this props to add an icon name to BIMDataIcon.",
-          "addFile",
-        ],
-        [
           "color",
           "String",
           "",
-          "currentColor",
+          "default that matches currentColor",
           "This props allows you to customize the color of the icon's fill.",
-          "red, blue, green...",
-        ],
-        [
-          "size",
-          "String",
-          "",
-          "s",
-          "Several custom size are available to handle the custom icons size.",
-          "xxxs, xxs, xs, s, m, l, xl, xxl, xxxl.",
+          "List of 'values' above",
         ],
         [
           "customSize",
@@ -205,12 +166,36 @@ export default {
           "25",
         ],
         [
+          "fillColor",
+          "String",
+          "",
+          "currentColor",
+          "Use this props if values colors is not enought for customize fill for icon.",
+          "red, blue, green...",
+        ],
+        [
+          "name",
+          "String",
+          "true",
+          "",
+          "Use this props to add an icon name to BIMDataIcon.",
+          "addFile",
+        ],
+        [
           "rotate",
           "Number",
           "",
           "0",
           "Use this props for rotate your icon.",
           "90, 180",
+        ],
+        [
+          "size",
+          "String",
+          "",
+          "s",
+          "Several custom size are available to handle the custom icons size.",
+          "xxxs, xxs, xs, s, m, l, xl, xxl, xxxl.",
         ],
       ],
       iconsSizeData: [
@@ -257,6 +242,9 @@ export default {
       if (this.rotationDeg > 0) {
         return `:rotate="${this.rotationDeg}"`;
       }
+    },
+    getOverviewIconClasses() {
+      return `icon-${this.selectedIconOptionstypes} icon-${this.selectedIconOptionstypes}--${this.selectedIconOptionsvalues}`;
     },
   },
 };


### PR DESCRIPTION
- add iconsColors file (we do not have the same colors as for the BIMDataButton)
- use fill or stroke prop
- use color="myVariableColor" to define icon's color
- use "fillColor" prop to add fill values other than those defined by BIMData
- add documentation

Now, we can use BIMDataIcon like that : 
`<BIMDataIcon name="addFile" fill color="primary" />`

instead of : 
`<BIMDataIcon name="addFile"  class="fill-primary" />`