### PR TITLE
add width & height to bimdata-dropdown-list

### DIFF
--- a/src/BIMDataComponents/BIMDataDropdownList/BIMDataDropdownList.vue
+++ b/src/BIMDataComponents/BIMDataDropdownList/BIMDataDropdownList.vue
@@ -4,6 +4,7 @@
     v-clickaway="away"
     :direction="directionClass"
     :closeOnElementClick="closeOnElementClick"
+    :style="style"
   >
     <div
       class="bimdata-dropdown-list__content"


### PR DESCRIPTION
current state : the minimum width and height were assigned to the first child of bimdata-dropdown-list. When using the component, the parent had to be assigned a width so that the dropdown list was not wider than its parent.

new state : the same height and width assigned to the first child, are also assigned to the parent.