### PR TITLE
chore: update api-client version to use new model api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0-rc.23",
       "devDependencies": {
         "@babel/preset-env": "^7.10.2",
-        "@bimdata/typescript-fetch-api-client": "^6.17.2",
+        "@bimdata/typescript-fetch-api-client": "^7.0.0",
         "@rollup/plugin-alias": "^3.1.1",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-image": "^2.1.1",
@@ -1233,9 +1233,9 @@
       }
     },
     "node_modules/@bimdata/typescript-fetch-api-client": {
-      "version": "6.17.2",
-      "resolved": "https://registry.npmjs.org/@bimdata/typescript-fetch-api-client/-/typescript-fetch-api-client-6.17.2.tgz",
-      "integrity": "sha512-MsXImG3NHTlvfOHYU1VulJrZCUq1/gvN5wLFIzM7frJ1ycEBnbS73+Q/zN0NvmayOf+MQP1VWHr1UBPI1y1+mg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@bimdata/typescript-fetch-api-client/-/typescript-fetch-api-client-7.0.0.tgz",
+      "integrity": "sha512-pMo49Lv5kJ6oBQPXqAXBW881tuRkHwCTL3OeRhil3vIiDOx10b+1OkwHTaqHtNKDnfa7535kZJ+2SmDAsnCVnA==",
       "dev": true
     },
     "node_modules/@cnakazawa/watch": {
@@ -17619,6 +17619,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -28314,9 +28319,9 @@
       }
     },
     "@bimdata/typescript-fetch-api-client": {
-      "version": "6.17.2",
-      "resolved": "https://registry.npmjs.org/@bimdata/typescript-fetch-api-client/-/typescript-fetch-api-client-6.17.2.tgz",
-      "integrity": "sha512-MsXImG3NHTlvfOHYU1VulJrZCUq1/gvN5wLFIzM7frJ1ycEBnbS73+Q/zN0NvmayOf+MQP1VWHr1UBPI1y1+mg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@bimdata/typescript-fetch-api-client/-/typescript-fetch-api-client-7.0.0.tgz",
+      "integrity": "sha512-pMo49Lv5kJ6oBQPXqAXBW881tuRkHwCTL3OeRhil3vIiDOx10b+1OkwHTaqHtNKDnfa7535kZJ+2SmDAsnCVnA==",
       "dev": true
     },
     "@cnakazawa/watch": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.10.2",
-    "@bimdata/typescript-fetch-api-client": "^6.17.2",
+    "@bimdata/typescript-fetch-api-client": "^7.0.0",
     "@rollup/plugin-alias": "^3.1.1",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-image": "^2.1.1",


### PR DESCRIPTION
This is needed in order to have the `model_id` and `model_type` fields available when using `<BIMDataFilesManager />`