### PR TITLE
add message as property for BIMDataLoading

### DIFF
--- a/src/BIMDataComponents/BIMDataLoading/BIMDataLoading.vue
+++ b/src/BIMDataComponents/BIMDataLoading/BIMDataLoading.vue
@@ -2,8 +2,8 @@
   <div class="bimdata-loading">
     <span class="bimdata-loading--square"></span>
     <BIMDataText color="color-white" margin="12px 0 0"
-      ><span>{{ message }}</span
-      ><br /><span>{{ subMessage }}</span></BIMDataText
+      ><p>{{ message }}</p>
+      <p>{{ subMessage }}</p></BIMDataText
     >
   </div>
 </template>

--- a/src/BIMDataComponents/BIMDataLoading/BIMDataLoading.vue
+++ b/src/BIMDataComponents/BIMDataLoading/BIMDataLoading.vue
@@ -2,7 +2,8 @@
   <div class="bimdata-loading">
     <span class="bimdata-loading--square"></span>
     <BIMDataText color="color-white" margin="12px 0 0"
-      ><span>loading...</span></BIMDataText
+      ><span>{{ message }}</span
+      ><br /><span>{{ subMessage }}</span></BIMDataText
     >
   </div>
 </template>
@@ -12,6 +13,16 @@ import BIMDataText from "../BIMDataText/BIMDataText.vue";
 export default {
   components: {
     BIMDataText,
+  },
+  props: {
+    message: {
+      type: String,
+      default: "loading...",
+    },
+    subMessage: {
+      type: String,
+      default: "",
+    },
   },
 };
 </script>

--- a/src/BIMDataComponents/BIMDataLoading/_BIMDataLoading.scss
+++ b/src/BIMDataComponents/BIMDataLoading/_BIMDataLoading.scss
@@ -34,5 +34,6 @@
   }
   p {
     text-align: center;
+    margin: 0;
   }
 }

--- a/src/BIMDataComponents/BIMDataLoading/_BIMDataLoading.scss
+++ b/src/BIMDataComponents/BIMDataLoading/_BIMDataLoading.scss
@@ -32,4 +32,7 @@
     margin-top: 12px;
     display: block;
   }
+  p {
+    text-align: center;
+  }
 }

--- a/src/web/views/Components/Loaders/Loaders.vue
+++ b/src/web/views/Components/Loaders/Loaders.vue
@@ -27,6 +27,15 @@
           form validation)
         </p>
       </div>
+      <div class="m-t-12">
+        <BIMDataText component="h5" color="color-primary" margin="15px 0 0"
+          >BIMDataLoading props:</BIMDataText
+        >
+        <BIMDataTable
+          :columns="propsBIMDataLoading[0]"
+          :rows="propsBIMDataLoading.slice(1)"
+        ></BIMDataTable>
+      </div>
 
       <ComponentCode class="m-t-12" language="javascript">
         <template #module>
@@ -142,6 +151,11 @@ export default {
   },
   data() {
     return {
+      propsBIMDataLoading: [
+        ["Props", "Type", "Default value", "Description"],
+        ["message", "String", "loading...", "custom waiting message"],
+        ["subMessage", "String", "", "custom waiting sub-message"],
+      ],
       propsBIMDataPieSpinner: [
         ["Props", "Type", "Default value", "Description"],
         ["width", "Number", "22", "Spinner width"],


### PR DESCRIPTION
Hello team,

Here is a PR that add 2 properties for the Loading component
* message: to replace the default text 'loading...'
* subMessage: add an extra space to put content in 

I thought to add a third property "color", but there is no need for now, let me know if you want me to add it anyway

Also, the doc for the loaders page looks "old school" because it's not possible to modify properties dynamically (in comparaison to BIMDataInput for exemple). Let me know if you want me to update that 

Paul

