### PR TITLE
feat(select): add nullLabel prop

### DIFF
--- a/src/BIMDataComponents/BIMDataSelect/BIMDataSelect.vue
+++ b/src/BIMDataComponents/BIMDataSelect/BIMDataSelect.vue
@@ -51,6 +51,9 @@ export default {
       type: Boolean,
       default: false,
     },
+    nullLabel: {
+      type: String,
+    },
     disabled: {
       type: Boolean,
       default: false,

--- a/src/BIMDataComponents/BIMDataSelect/BIMDataSelectMulti.vue
+++ b/src/BIMDataComponents/BIMDataSelect/BIMDataSelectMulti.vue
@@ -87,6 +87,9 @@ export default {
     modelValue: {
       type: Array,
     },
+    nullLabel: {
+      type: String,
+    },
     disabled: {
       type: Boolean,
       default: false,
@@ -116,6 +119,9 @@ export default {
       return option;
     },
     optionLabel(option) {
+      if (this.nullLabel && option == null) {
+        return this.nullLabel;
+      }
       if (this.optionLabelKey && option) {
         return option[this.optionLabelKey];
       }

--- a/src/BIMDataComponents/BIMDataSelect/BIMDataSelectSingle.vue
+++ b/src/BIMDataComponents/BIMDataSelect/BIMDataSelectSingle.vue
@@ -27,7 +27,7 @@
           class="bimdata-select__option-list__entry"
           @click="onNullValueClick()"
         >
-          None
+          {{ nullLabel || "None" }}
         </li>
         <li
           class="bimdata-select__option-list__entry"
@@ -88,6 +88,9 @@ export default {
       type: Boolean,
       default: false,
     },
+    nullLabel: {
+      type: String,
+    },
     disabled: {
       type: Boolean,
       default: false,
@@ -117,6 +120,9 @@ export default {
       return option;
     },
     optionLabel(option) {
+      if (this.nullLabel && option == null) {
+        return this.nullLabel;
+      }
       if (this.optionLabelKey && option) {
         return option[this.optionLabelKey];
       }

--- a/src/web/views/Components/Select/props-data.js
+++ b/src/web/views/Components/Select/props-data.js
@@ -55,6 +55,12 @@ export default [
     + "Add a 'none' value in single-selection mode.",
   ],
   [
+    "nullLabel",
+    "String",
+    "",
+    "Define a custom label for `null` or `undefined` options."
+  ],
+  [
     "disabled",
     "Boolean",
     "false",


### PR DESCRIPTION
This PR add a **nullLabel** prop to BIMDataSelect in order to define a custom label if an option is `null` or `undefined`.