### PR TITLE
PATCH: fix rollup-plugin-css-only version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "prismjs": "^1.29.0",
         "rollup": "^2.79.0",
         "rollup-plugin-copy": "^3.4.0",
-        "rollup-plugin-css-only": "^3.1.0",
+        "rollup-plugin-css-only": "2.1.0",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-vue2": "npm:rollup-plugin-vue@^5.1.9",
@@ -18353,31 +18353,19 @@
       }
     },
     "node_modules/rollup-plugin-css-only": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-css-only/-/rollup-plugin-css-only-3.1.0.tgz",
-      "integrity": "sha512-TYMOE5uoD76vpj+RTkQLzC9cQtbnJNktHPB507FzRWBVaofg7KhIqq1kGbcVOadARSozWF883Ho9KpSPKH8gqA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-css-only/-/rollup-plugin-css-only-2.1.0.tgz",
+      "integrity": "sha512-pfdcqAWEmRMFy+ABXAQPA/DKyPqLuBTOf+lWSOgtrVs1v/q7DSXzYa9QZg4myd8/1F7NHcdvPkWnfWqMxq9vrw==",
       "dev": true,
       "dependencies": {
-        "@rollup/pluginutils": "4"
+        "@rollup/pluginutils": "^3.0.0",
+        "fs-extra": "^9.0.0"
       },
       "engines": {
         "node": ">=10.12.0"
       },
       "peerDependencies": {
         "rollup": "1 || 2"
-      }
-    },
-    "node_modules/rollup-plugin-css-only/node_modules/@rollup/pluginutils": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-      "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-      "dev": true,
-      "dependencies": {
-        "estree-walker": "^2.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/rollup-plugin-postcss": {
@@ -35032,24 +35020,13 @@
       }
     },
     "rollup-plugin-css-only": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-css-only/-/rollup-plugin-css-only-3.1.0.tgz",
-      "integrity": "sha512-TYMOE5uoD76vpj+RTkQLzC9cQtbnJNktHPB507FzRWBVaofg7KhIqq1kGbcVOadARSozWF883Ho9KpSPKH8gqA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-css-only/-/rollup-plugin-css-only-2.1.0.tgz",
+      "integrity": "sha512-pfdcqAWEmRMFy+ABXAQPA/DKyPqLuBTOf+lWSOgtrVs1v/q7DSXzYa9QZg4myd8/1F7NHcdvPkWnfWqMxq9vrw==",
       "dev": true,
       "requires": {
-        "@rollup/pluginutils": "4"
-      },
-      "dependencies": {
-        "@rollup/pluginutils": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-          "integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
-          "dev": true,
-          "requires": {
-            "estree-walker": "^2.0.1",
-            "picomatch": "^2.2.2"
-          }
-        }
+        "@rollup/pluginutils": "^3.0.0",
+        "fs-extra": "^9.0.0"
       }
     },
     "rollup-plugin-postcss": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prismjs": "^1.29.0",
     "rollup": "^2.79.0",
     "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-css-only": "^3.1.0",
+    "rollup-plugin-css-only": "2.1.0",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-vue2": "npm:rollup-plugin-vue@^5.1.9",


### PR DESCRIPTION
keep version 2.1.0 to be able to write path to css bundle directory