### PR TITLE
dropdown / handle empty items for sub menu

### DIFF
--- a/src/BIMDataComponents/BIMDataDropdownMenu/BIMDataDropdownMenu.vue
+++ b/src/BIMDataComponents/BIMDataDropdownMenu/BIMDataDropdownMenu.vue
@@ -23,17 +23,17 @@
               :key="item.name"
               class="bimdata-dropdown__elements__menu-items__item"
               :style="{
-                color: isChildEmpty(item.children)
+                color: hasNoChildren(item.children)
                   ? 'var(--color-silver-dark)'
                   : 'var(--color-primary)',
               }"
               @click.stop="
-                !isChildEmpty(item.children) && item.action && item.action()
+                !hasNoChildren(item.children) && item.action && item.action()
               "
               @mouseover="
-                !isChildEmpty(item.children) && handleCurrentItem(item.name)
+                !hasNoChildren(item.children) && handleCurrentItem(item.name)
               "
-              @mouseleave="!isChildEmpty(item.children) && handleCurrentItem()"
+              @mouseleave="!hasNoChildren(item.children) && handleCurrentItem()"
             >
               <BIMDataTextbox :text="item.name" />
               <template v-if="item.children">
@@ -137,7 +137,7 @@ export default {
         this.currentItemName = null;
       }
     },
-    isChildEmpty(childList) {
+    hasNoChildren(childList) {
       return childList && childList.length === 0;
     },
   },

--- a/src/BIMDataComponents/BIMDataDropdownMenu/BIMDataDropdownMenu.vue
+++ b/src/BIMDataComponents/BIMDataDropdownMenu/BIMDataDropdownMenu.vue
@@ -22,9 +22,18 @@
               v-for="item in menuItems"
               :key="item.name"
               class="bimdata-dropdown__elements__menu-items__item"
-              @click="item.action && item.action()"
-              @mouseover="handleCurrentItem(item.name)"
-              @mouseleave="handleCurrentItem()"
+              :style="{
+                color: isChildEmpty(item.children)
+                  ? 'var(--color-silver-dark)'
+                  : 'var(--color-primary)',
+              }"
+              @click.stop="
+                !isChildEmpty(item.children) && item.action && item.action()
+              "
+              @mouseover="
+                !isChildEmpty(item.children) && handleCurrentItem(item.name)
+              "
+              @mouseleave="!isChildEmpty(item.children) && handleCurrentItem()"
             >
               <BIMDataTextbox :text="item.name" />
               <template v-if="item.children">
@@ -127,6 +136,9 @@ export default {
         this.isItemHover = false;
         this.currentItemName = null;
       }
+    },
+    isChildEmpty(childList) {
+      return childList && childList.length === 0;
     },
   },
 };


### PR DESCRIPTION
hello team,

This PR is related to this [issue](https://github.com/bimdata/platform-next/issues/294)              
The code aims to handle whether or not a sub dropdown menu has to be enabled

Two things are bothering me:

1. hasNoChildren method:
Since item.child could be: 
-- undefined: classic dropdown with no sub menu
-- empty array: sub menu with no items (disabled)
-- filled array: sub menu with items (enabled) 
I have to handle it by the negative "hasNo..." I would like to find an other way more readable

2. style attributes instead of class that handle style through .scss file
I tried something like below
```
 :class="`bimdata-dropdown__elements__menu-items__item__${
    hasNoChildren(item.children) ? 'no-children' : 'has-children'
  }`"
```

the correct class is applied, but the related style isn't

Paul