### PR TITLE
dropdown-menu / handle no header

### DIFF
--- a/src/BIMDataComponents/BIMDataDropdownMenu/BIMDataDropdownMenu.vue
+++ b/src/BIMDataComponents/BIMDataDropdownMenu/BIMDataDropdownMenu.vue
@@ -16,11 +16,11 @@
         v-show="displayed"
         class="submenu bimdata-dropdown__elements"
         :class="[
-          { 'no-header': !header },
-          `submenu--${header ? directionClass : 'no-direction'}`,
+          { 'no-header': !menuHeader },
+          `submenu--${menuHeader ? directionClass : 'no-direction'}`,
         ]"
         :style="{
-          width: !header && width,
+          width: !menuHeader && width,
         }"
         @click="away()"
       >
@@ -109,6 +109,10 @@ export default {
       type: Array,
       default: () => [],
     },
+    header: {
+      type: Boolean,
+      default: true,
+    },
     subListMaxHeight: {
       type: String,
       default: "auto",
@@ -116,7 +120,7 @@ export default {
   },
   data() {
     return {
-      header: true,
+      menuHeader: true,
       displayed: false,
       isItemHover: false,
       currentItemName: null,
@@ -127,25 +131,20 @@ export default {
       return {
         "min-width": `${this.width}`,
         "min-height": `${this.height}`,
-        visibility: this.header ? "visible" : "hidden",
+        visibility: this.menuHeader ? "visible" : "hidden",
       };
     },
   },
-  mounted() {
-    this.mutationObserver = new MutationObserver(this.isHeaderDisplayed);
-    this.mutationObserver.observe(this.$refs.dropdown, {
-      childList: true,
-      subtree: true,
-    });
+  watch: {
+    header: {
+      immediate: true,
+      handler(header) {
+        this.menuHeader = header;
+        if (!header) this.displayed = true;
+      },
+    },
   },
   methods: {
-    isHeaderDisplayed() {
-      this.header = this.$refs.header.innerHTML !== "";
-
-      if (!this.header) {
-        this.displayed = true;
-      }
-    },
     definePos(item) {
       if (!item.children.position || !item.children.position === "up") return 0;
 

--- a/src/BIMDataComponents/BIMDataDropdownMenu/BIMDataDropdownMenu.vue
+++ b/src/BIMDataComponents/BIMDataDropdownMenu/BIMDataDropdownMenu.vue
@@ -1,7 +1,6 @@
 <template>
-  <div ref="dropdown" class="bimdata-dropdown" v-clickaway="away">
+  <div class="bimdata-dropdown" v-clickaway="away">
     <div
-      ref="header"
       class="bimdata-dropdown__content"
       :class="{ active: displayed, disabled }"
       @click="onHeaderClick"

--- a/src/BIMDataComponents/BIMDataDropdownMenu/BIMDataDropdownMenu.vue
+++ b/src/BIMDataComponents/BIMDataDropdownMenu/BIMDataDropdownMenu.vue
@@ -90,7 +90,7 @@ export default {
       type: String,
       default: "down",
       validator: directionClass =>
-        ["down", "up", "right", "left", "none"].includes(directionClass),
+        ["down", "up", "right", "left"].includes(directionClass),
     },
     width: {
       type: String,

--- a/src/BIMDataComponents/BIMDataDropdownMenu/_BIMDataDropdownMenu.scss
+++ b/src/BIMDataComponents/BIMDataDropdownMenu/_BIMDataDropdownMenu.scss
@@ -37,8 +37,17 @@
   &__elements {
     font-size: 11px;
 
+    &.no-header {
+      top: 50%;
+      left: 50%;
+      width: 220px;
+      position: absolute;
+      transform: translate(-50%, -50%);
+    }
+
     &__menu-items {
       padding-left: 0px;
+      overflow: visible;
       margin: 0;
 
       &__item {
@@ -69,7 +78,7 @@
       }
     }
 
-    &:first-child {
+    &:first-child :not(&__menu-items) {
       padding: calc(#{var(--spacing-unit)} / 2) 0;
       overflow: auto;
       z-index: 1;

--- a/src/assets/scss/elements/_BIMDataSubmenus.scss
+++ b/src/assets/scss/elements/_BIMDataSubmenus.scss
@@ -23,7 +23,8 @@
   &--up,
   &--down,
   &--right,
-  &--left {
+  &--left,
+  &--no-direction {
     padding: calc(var(--spacing-unit) / 2) 0;
     width: 100%;
     left: 0;

--- a/src/web/views/Components/DropdownMenu/DropdownMenu.vue
+++ b/src/web/views/Components/DropdownMenu/DropdownMenu.vue
@@ -184,7 +184,7 @@ export default {
           "directionClass",
           "String",
           "'down'",
-          "'up', 'down', 'right', 'left' or 'none' values",
+          "'up', 'down', 'right' or 'left' values",
           "Use this props to choose the opening of the submenu.",
         ],
         [

--- a/src/web/views/Components/DropdownMenu/DropdownMenu.vue
+++ b/src/web/views/Components/DropdownMenu/DropdownMenu.vue
@@ -12,6 +12,7 @@
             :transitionName="selectedDropdownOptionstransition"
             :directionClass="selectedDropdownOptionsdirection"
             :menuItems="checkboxTwoLevelChecked ? multiLevelList : []"
+            :header="checkboxDisabledHeader"
           >
             <template #header v-if="checkboxHeaderChecked">
               <span>dropdown menu example</span>
@@ -36,6 +37,12 @@
             class="m-y-12"
             text="disabled"
             v-model="checkboxDisabledChecked"
+          >
+          </BIMDataCheckbox>
+          <BIMDataCheckbox
+            class="m-y-12"
+            text="header"
+            v-model="checkboxDisabledHeader"
           >
           </BIMDataCheckbox>
           <BIMDataText component="h5" color="color-primary" margin="15px 0 10px"
@@ -92,6 +99,7 @@
           <pre>
             &lt;BIMDataDropdownMenu
               :disabled="{{ checkboxDisabledChecked }}"
+              :header="{{ getHeaderProp() }}"
               {{ getMenuItems() }}
             &gt;
               {{ getHeader() }} {{ getContentAfterBtn() }} {{ getElement() }}
@@ -139,7 +147,8 @@ export default {
     return {
       checkboxDisabledChecked: false,
       checkboxTwoLevelChecked: false,
-      checkboxHeaderChecked: true,
+      checkboxHeaderChecked: false,
+      checkboxDisabledHeader: true,
       checkboxAfterHeaderChecked: false,
       checkboxElementSlotChecked: false,
       customListCheckbox: false,
@@ -204,6 +213,13 @@ export default {
           "Use this props to custom height of BIMDataDropdownList component.",
         ],
         [
+          "header",
+          "Boolean",
+          "true",
+          "",
+          "Use this props to not display the header.",
+        ],
+        [
           "menuItems",
           "Array",
           "[]",
@@ -262,6 +278,13 @@ export default {
     getMenuItems() {
       if (this.checkboxTwoLevelChecked) {
         return `:menuItems=${JSON.stringify(this.multiLevelList)}`;
+      }
+    },
+    getHeaderProp() {
+      if (this.checkboxDisabledHeader) {
+        return true;
+      } else {
+        return false;
       }
     },
   },

--- a/src/web/views/Components/DropdownMenu/DropdownMenu.vue
+++ b/src/web/views/Components/DropdownMenu/DropdownMenu.vue
@@ -92,6 +92,7 @@
           <pre>
             &lt;BIMDataDropdownMenu
               :disabled="{{ checkboxDisabledChecked }}"
+              {{ getMenuItems() }}
             &gt;
               {{ getHeader() }} {{ getContentAfterBtn() }} {{ getElement() }}
             &lt;/BIMDataDropdownMenu&gt;
@@ -152,22 +153,23 @@ export default {
       multiLevelList: [
         {
           name: "project1",
-          children: [
-            { name: "project1.1" },
-            { name: "project1.2" },
-            { name: "project1.3" },
-          ],
+          children: {
+            position: "up",
+            list: [{ name: "project1.1" }],
+          },
         },
-        { name: "project2", action: () => console.log("I'm clicked") },
+        { name: "project2", action: () => console.log("clicked") },
         {
           name: "project3",
-          children: [
-            {
-              name: "project3.1",
-              action: () => console.log("I'm clicked"),
-            },
-            { name: "project3.2" },
-          ],
+          children: {
+            list: [
+              {
+                name: "project3.1",
+                action: () => console.log("clicked"),
+              },
+              { name: "project3.2" },
+            ],
+          },
         },
       ],
       propsData: [
@@ -255,6 +257,11 @@ export default {
               </ul>
             </template>
             `;
+      }
+    },
+    getMenuItems() {
+      if (this.checkboxTwoLevelChecked) {
+        return `:menuItems=${JSON.stringify(this.multiLevelList)}`;
       }
     },
   },

--- a/src/web/views/Components/DropdownMenu/DropdownMenu.vue
+++ b/src/web/views/Components/DropdownMenu/DropdownMenu.vue
@@ -184,7 +184,7 @@ export default {
           "directionClass",
           "String",
           "'down'",
-          "'up', 'down', 'right' or 'left' values",
+          "'up', 'down', 'right', 'left' or 'none' values",
           "Use this props to choose the opening of the submenu.",
         ],
         [


### PR DESCRIPTION
hello team,

This PR brings a different way to use the the dropdown menu
In order to apply the design below, I made the dropdown to whether or no accept a "header" slot 
So from now on, when the dropdown is called without header, the menu will be displayed straightaway

I also added a method that align children menu dynamically to it parent


![Screenshot 2022-10-19 at 15 33 10](https://user-images.githubusercontent.com/64323277/196706112-c8b447f2-62c5-4d53-8655-76d8ce566d49.png)
![Screenshot 2022-10-19 at 15 33 17](https://user-images.githubusercontent.com/64323277/196706144-f2b6c85a-2cc6-4bfb-90fb-db8f8964ca90.png)

