### PR TITLE
fix breakdown issue / add custom attribute

### DIFF
--- a/src/BIMDataComponents/BIMDataCheckbox/BIMDataCheckbox.vue
+++ b/src/BIMDataComponents/BIMDataCheckbox/BIMDataCheckbox.vue
@@ -4,6 +4,7 @@
     :class="{ indeterminate, disabled, checked }"
     @click="onClick"
     :style="style"
+    v-bind="$attrs"
   >
     <span class="bimdata-checkbox__mark"></span>
     <span class="bimdata-checkbox__text" v-if="text">

--- a/src/BIMDataSmartComponents/BIMDataFileManager/BIMDataFileManager.vue
+++ b/src/BIMDataSmartComponents/BIMDataFileManager/BIMDataFileManager.vue
@@ -153,7 +153,7 @@ import { downloadFiles } from "./utils/files.js";
 
 import trads from "./i18n.js";
 
-const XS = 375;
+const XS = 398;
 const S = 468;
 const M = 800;
 


### PR DESCRIPTION
This PR brings two things

* fix the breakdown issue on BIMDataFileManager in viewer (I tested the FileManager with this new setting in the two other implementations (building maker viewer and platform -> eveything works)
* possibility to add custom attributes on BIMDataCheckbox -> I need it to trigger an event in Cypress ("data-test-id")

Paul