### PR TITLE
Fix/bimdata responsive grid

### DIFF
--- a/src/BIMDataComponents/BIMDataResponsiveGrid/BIMDataResponsiveGrid.vue
+++ b/src/BIMDataComponents/BIMDataResponsiveGrid/BIMDataResponsiveGrid.vue
@@ -4,7 +4,7 @@
     :style="{
       gridTemplateColumns: isRepeatFit
         ? `repeat(auto-fit, minmax(${itemWidth}, 1fr))`
-        : `repeat(auto-fill, ${itemWidth})`,
+        : `repeat(auto-fill, minmax(${itemWidth}, 1fr))`,
       rowGap,
       columnGap,
     }"

--- a/src/BIMDataComponents/BIMDataResponsiveGrid/BIMDataResponsiveGrid.vue
+++ b/src/BIMDataComponents/BIMDataResponsiveGrid/BIMDataResponsiveGrid.vue
@@ -2,7 +2,9 @@
   <div
     class="bimdata-responsive-grid"
     :style="{
-      gridTemplateColumns: `repeat(auto-fill, ${itemWidth})`,
+      gridTemplateColumns: isRepeatFit
+        ? `repeat(auto-fit, minmax(${itemWidth}, 1fr))`
+        : `repeat(auto-fill, ${itemWidth})`,
       rowGap,
       columnGap,
     }"
@@ -25,6 +27,10 @@ export default {
     columnGap: {
       type: String,
       default: "12px",
+    },
+    isRepeatFit: {
+      type: Boolean,
+      default: false,
     },
   },
 };

--- a/src/BIMDataSmartComponents/BIMDataFileManager/BIMDataFileManager.vue
+++ b/src/BIMDataSmartComponents/BIMDataFileManager/BIMDataFileManager.vue
@@ -79,7 +79,6 @@
           :itemWidth="itemWidth"
           rowGap="4px"
           columnGap="6px"
-          :isRepeatFit="true"
         >
           <FileCard
             :width="itemWidth"

--- a/src/BIMDataSmartComponents/BIMDataFileManager/BIMDataFileManager.vue
+++ b/src/BIMDataSmartComponents/BIMDataFileManager/BIMDataFileManager.vue
@@ -79,6 +79,7 @@
           :itemWidth="itemWidth"
           rowGap="4px"
           columnGap="6px"
+          :isRepeatFit="true"
         >
           <FileCard
             :width="itemWidth"

--- a/src/web/_DesignSystem-global.scss
+++ b/src/web/_DesignSystem-global.scss
@@ -59,12 +59,11 @@ pre[class*="language-"] {
   overflow-y: auto;
   overflow-x: hidden;
   .article-wrapper {
+    margin: 30px 90px;
     width: 100%;
     width: calc(100% - 180px);
     display: flex;
     flex-direction: column;
-    margin: 30px 90px;
-    max-width: 1420px;
     position: relative;
     display: flex;
     flex-direction: column;

--- a/src/web/views/Components/ResponsiveGrid/ResponsiveGrid.vue
+++ b/src/web/views/Components/ResponsiveGrid/ResponsiveGrid.vue
@@ -53,6 +53,7 @@
               {{ `itemWidth="${itemWidth}"` }}
               {{ `rowGap="${rowGap}"` }}
               {{ `columnGap="${columnGap}"` }}
+              {{ `:isRepeatFit="${checkboxFitItemsChecked}"` }}
             &gt;
               &lt;div
                 {{ `style="width: 100%; height: ${itemWidth}"` }}

--- a/src/web/views/Components/ResponsiveGrid/ResponsiveGrid.vue
+++ b/src/web/views/Components/ResponsiveGrid/ResponsiveGrid.vue
@@ -11,10 +11,11 @@
             :itemWidth="itemWidth"
             :rowGap="rowGap"
             :columnGap="columnGap"
+            :isRepeatFit="checkboxFitItemsChecked"
           >
             <div
               class="demo-grid-item"
-              :style="{ width: itemWidth, height: itemWidth }"
+              :style="{ width: '100%', height: itemWidth }"
               v-for="(n, i) of Array.from({ length: +nbItem })"
               :key="i"
             >
@@ -34,6 +35,10 @@
             <BIMDataInput v-model="itemWidth" placeholder="Item width" />
             <BIMDataInput v-model="rowGap" placeholder="Row gap" />
             <BIMDataInput v-model="columnGap" placeholder="Column gap" />
+            <BIMDataCheckbox
+              text="Fit items to grid"
+              v-model="checkboxFitItemsChecked"
+            />
           </div>
         </template>
 
@@ -50,7 +55,7 @@
               {{ `columnGap="${columnGap}"` }}
             &gt;
               &lt;div
-                {{ `style="width: ${itemWidth}; height: ${itemWidth}"` }}
+                {{ `style="width: 100%; height: ${itemWidth}"` }}
                 v-for="i of items"
                 :key="i"
               &gt;
@@ -74,6 +79,7 @@
 <script>
 import ComponentCode from "../../Elements/ComponentCode/ComponentCode.vue";
 
+import BIMDataCheckbox from "../../../../../src/BIMDataComponents/BIMDataCheckbox/BIMDataCheckbox.vue";
 import BIMDataInput from "../../../../../src/BIMDataComponents/BIMDataInput/BIMDataInput.vue";
 import BIMDataResponsiveGrid from "../../../../../src/BIMDataComponents/BIMDataResponsiveGrid/BIMDataResponsiveGrid.vue";
 import BIMDataTable from "../../../../../src/BIMDataComponents/BIMDataTable/BIMDataTable.vue";
@@ -82,6 +88,7 @@ import BIMDataText from "../../../../../src/BIMDataComponents/BIMDataText/BIMDat
 export default {
   components: {
     ComponentCode,
+    BIMDataCheckbox,
     BIMDataInput,
     BIMDataResponsiveGrid,
     BIMDataTable,
@@ -93,11 +100,23 @@ export default {
       itemWidth: "150px",
       rowGap: "6px",
       columnGap: "18px",
+      checkboxFitItemsChecked: false,
       propsData: [
         ["Props", "Type", "Default value", "Description"],
         ["itemWidth", "String", "100px", "Define available width for items"],
         ["rowGap", "String", "12px", "Define the space between two rows"],
-        ["columnGap", "String", "12px", "Define the space between two columns"],
+        [
+          "columnGap",
+          "String",
+          "12px",
+          "Define the space between two columns.",
+        ],
+        [
+          "isRepeatFit",
+          "Boolean",
+          "false",
+          "Set this props to 'true' If you want fits the currently available columns into the space by expanding them so that they take up any available space. By default, the component fills the row with as many columns as it can fit.",
+        ],
       ],
     };
   },

--- a/src/web/views/GettingStarted/Developpers.vue
+++ b/src/web/views/GettingStarted/Developpers.vue
@@ -4,7 +4,7 @@
       <BIMDataText component="h1" color="color-primary">{{
         $route.name
       }}</BIMDataText>
-      <BIMDataText margin="5px 0"
+      <BIMDataText margin="5px 0" lineHeight="24px"
         >How to get started with BIMData's vuejs component library</BIMDataText
       >
       <BIMDataText component="h4" color="color-primary" margin="20px 0 10px"
@@ -15,9 +15,7 @@
         <code class="code-highlight">design-system</code>, and it’s available on
         the npm registry.</BIMDataText
       >
-      <Code language="bash">
-        npm i @bimdata/design-system
-      </Code>
+      <Code language="bash"> npm i @bimdata/design-system </Code>
 
       <BIMDataText component="h4" color="color-primary" margin="20px 0 10px"
         >2. Import component</BIMDataText

--- a/src/web/views/GettingStarted/InternalDoc.vue
+++ b/src/web/views/GettingStarted/InternalDoc.vue
@@ -4,7 +4,7 @@
       <BIMDataText component="h1" color="color-primary">{{
         $route.name
       }}</BIMDataText>
-      <BIMDataText margin="5px 0 10px"
+      <BIMDataText margin="5px 0 10px" lineHeight="24px"
         >All the design system resources are in the directory:
         <code class="code-highlight">src/web/views</code>. The following
         explanations concern the addition of a new component. If you want to add
@@ -15,7 +15,7 @@
       <BIMDataText component="h3" color="color-primary" margin="20px 0 10px"
         >How to add a new component to the design system</BIMDataText
       >
-      <ol>
+      <ol class="color-granite">
         <li>
           In the <code class="code-highlight">Components</code> directory create
           a new directory with the name of your component. Inside it, create
@@ -85,11 +85,11 @@
       <BIMDataText component="h3" color="color-primary" margin="20px 0 10px">
         How to add a new component to the build of design system
       </BIMDataText>
-      <p>
+      <p class="color-granite">
         For a correct build, don't forget to add your new component in the
         following 3 files:
       </p>
-      <ul>
+      <ul class="color-granite">
         <li>./rollup.config.js</li>
         <li>./components.js</li>
         <li>./src/BIMDataComponents/index.js</li>

--- a/src/web/views/Layout/Content.vue
+++ b/src/web/views/Layout/Content.vue
@@ -9,7 +9,7 @@
       </BIMDataText>
       <div class="content-box">
         <BIMDataCard
-          class="bimdata-card__secondary"
+          class="bimdata-card__secondary getting-started__card"
           v-if="$route.name === 'Components'"
         >
           <template #content>
@@ -26,47 +26,53 @@
                 Learn how to quickly get started with our component library to
                 build expressive, consistent UI at BIMData.
               </BIMDataText>
-              <BIMDataButton width="150" color="primary" radius fill>
+              <BIMDataButton width="150px" color="primary" radius fill>
                 Get started now
               </BIMDataButton>
             </router-link>
           </template>
         </BIMDataCard>
 
-        <BIMDataCard
-          v-for="child in $store.state[$route.name].children"
-          :key="child.id"
-          :class="{
-            'bimdata-card__secondary':
-              child.title === 'Variables' || child.title === 'Utilities',
-          }"
+        <BIMDataResponsiveGrid
+          itemWidth="215px"
+          rowGap="18px"
+          columnGap="18px"
+          class="m-t-30"
         >
-          {{ child.title }}
-          <template #content>
-            <router-link :to="child.path" append>
-              <img
-                v-if="
-                  child.title !== 'Variables' || child.title !== 'Utilities'
-                "
-                :src="child.img"
-              />
-              <BIMDataText
-                component="h5"
-                color="color-primary"
-                margin="12px 0 0"
-                fontWeight="700"
-              >
-                {{ child.title }}
-              </BIMDataText>
-              <BIMDataText color="color-granite">
-                {{ child.text }}
-              </BIMDataText>
-              <BIMDataButton width="150" radius fill color="primary">
-                {{ child.btn }}
-              </BIMDataButton>
-            </router-link>
-          </template>
-        </BIMDataCard>
+          <BIMDataCard
+            v-for="child in $store.state[$route.name].children"
+            :key="child.id"
+            :class="{
+              'bimdata-card__secondary':
+                child.title === 'Variables' || child.title === 'Utilities',
+            }"
+          >
+            {{ child.title }}
+            <template #content>
+              <router-link :to="child.path" append>
+                <img
+                  v-if="
+                    child.title !== 'Variables' || child.title !== 'Utilities'
+                  "
+                  :src="child.img"
+                />
+                <BIMDataText
+                  component="h5"
+                  color="color-primary"
+                  fontWeight="700"
+                >
+                  {{ child.title }}
+                </BIMDataText>
+                <BIMDataText color="color-granite">
+                  {{ child.text }}
+                </BIMDataText>
+                <BIMDataButton width="120px" radius fill color="primary">
+                  {{ child.btn }}
+                </BIMDataButton>
+              </router-link>
+            </template>
+          </BIMDataCard>
+        </BIMDataResponsiveGrid>
       </div>
     </div>
   </main>
@@ -75,12 +81,14 @@
 <script>
 import BIMDataButton from "../../../../src/BIMDataComponents/BIMDataButton/BIMDataButton.vue";
 import BIMDataCard from "../../../../src/BIMDataComponents/BIMDataCard/BIMDataCard.vue";
+import BIMDataResponsiveGrid from "../../../../src/BIMDataComponents/BIMDataResponsiveGrid/BIMDataResponsiveGrid.vue";
 import BIMDataText from "../../../../src/BIMDataComponents/BIMDataText/BIMDataText.vue";
 
 export default {
   components: {
     BIMDataButton,
     BIMDataCard,
+    BIMDataResponsiveGrid,
     BIMDataText,
   },
   methods: {},

--- a/src/web/views/Layout/_DesignSystem-content.scss
+++ b/src/web/views/Layout/_DesignSystem-content.scss
@@ -3,10 +3,8 @@
     text-transform: capitalize;
   }
   &-box {
-    display: flex;
-    flex-wrap: wrap;
     .bimdata-card {
-      margin: 24px 24px 0 0;
+      height: 260px;
       min-height: 260px;
       display: inline-flex;
       flex: 0;
@@ -20,6 +18,7 @@
           flex-direction: column;
           align-items: center;
           justify-content: space-around;
+          gap: 0 18px;
           h5,
           p {
             color: var(--color-primary);
@@ -43,6 +42,19 @@
         h5,
         p {
           color: var(--color-primary);
+        }
+      }
+      &.getting-started__card {
+        width: 100%;
+        height: auto;
+        min-height: 80px;
+        a {
+          flex-direction: inherit;
+          align-items: center;
+          justify-content: space-between;
+        }
+        p {
+          height: auto;
         }
       }
       &:hover {


### PR DESCRIPTION
Add 'isRepeatFit' props ; set this props to 'true' If you want fits the currently available columns into the space by expanding them so that they take up any available space. By default, the component fills the row with as many columns as it can fit.

- [ ] I have tested my component
- [x] I have updated the documentation or there is no documentation needed
