### PR TITLE
clear BIMDataMenu

### DIFF
--- a/src/BIMDataComponents/BIMDataColorSelector/BIMDataColorSelector.vue
+++ b/src/BIMDataComponents/BIMDataColorSelector/BIMDataColorSelector.vue
@@ -13,7 +13,7 @@
           :key="`colorElement${j}ofColorLine${i}`"
           :style="`background-color: #${colorValue}`"
           :title="colorName"
-          @click="$emit('update:modelValue', colorValue)"
+          @click.stop="$emit('update:modelValue', colorValue)"
         ></div>
       </div>
     </template>

--- a/src/BIMDataComponents/BIMDataMenu/BIMDataMenu.vue
+++ b/src/BIMDataComponents/BIMDataMenu/BIMDataMenu.vue
@@ -119,6 +119,7 @@ export default {
       default: false,
     },
   },
+  emits: ["hover"],
   data() {
     return {
       hoveredItemKey: null,

--- a/src/BIMDataComponents/BIMDataMenu/BIMDataMenu.vue
+++ b/src/BIMDataComponents/BIMDataMenu/BIMDataMenu.vue
@@ -119,7 +119,6 @@ export default {
       default: false,
     },
   },
-  emits: ["hover"],
   data() {
     return {
       hoveredItemKey: null,
@@ -147,7 +146,6 @@ export default {
     },
     onMouseOver(item) {
       this.hoveredItemKey = item.key;
-      this.$emit("hover", item);
     },
   },
 };

--- a/src/BIMDataComponents/BIMDataMenu/BIMDataMenu.vue
+++ b/src/BIMDataComponents/BIMDataMenu/BIMDataMenu.vue
@@ -7,101 +7,78 @@
     }"
     v-clickaway="away"
   >
-    <div
-      :ref="`item-${item.key}`"
+    <li
       v-for="item in menuItems"
       :key="item.key"
       class="bimdata-menu__item flex"
       :class="[
-        item.divider ? 'bimdata-menu__item--divider' : '',
-        { hover: isItemHover && currentItemKey === item.key },
-        hasNoChildren(item) ? 'bimdata-menu__item--no-children' : '',
+        item.divider ? 'bimdata-menu__item__divider' : '',
+        { hover: hoveredItemKey === item.key },
       ]"
-      @click.stop="onClick(item)"
+      @click.stop="
+        onItemClick(item);
+        item.action && item.action();
+      "
       @mouseover="onMouseOver(item)"
-      @mouseleave="onMouseLeave(item)"
+      @mouseleave="hoveredItemKey = null"
       :style="{
         color: item.color,
       }"
     >
-      <div v-if="item.groupTitle" class="bimdata-menu__item--title">
+      <div v-if="item.groupTitle" class="bimdata-menu__item__title">
         <slot name="groupTitle" :item="item">
           <span>{{ item.groupTitle }}</span>
         </slot>
       </div>
-      <li
+      <div
         v-if="item.text"
         :style="{
           'background-color':
-            isItemHover && currentItemKey === item.key ? item.background : '',
-          display: 'flex',
+            hoveredItemKey === item.key ? item.background : '',
         }"
+        class="bimdata-menu__item__content flex"
+        :class="{ 'bimdata-menu__item__content--active': isItemActive(item) }"
       >
         <slot name="item" :item="item">
-          <BIMDataTextbox
-            :text="item.text"
-            :tooltip="false"
-            width="80%"
-            :style="{
-              marginLeft: childrenLeft ? (item.children ? '11px' : '24px') : '',
-            }"
+          <BIMDataTextbox :text="item.text" :tooltip="false" width="80%" />
+          <BIMDataIcon
+            v-if="item.children"
+            name="chevron"
+            size="xxs"
+            margin="0 0 0 auto"
           />
         </slot>
-        <template v-if="item.children">
+        <template v-if="isItemActive(item)">
           <slot name="children" :children="item.children" :item="item">
-            <BIMDataIcon name="chevron" size="xxs" margin="0 0 0 auto" />
-            <template v-if="isItemHover">
-              <template
-                v-if="hasNoChildren(item) && currentItemKey === item.key"
+            <template>
+              <div
+                class="bimdata-menu__item__children"
+                :style="{
+                  width: subListWidth,
+                  [childrenLeft ? 'left' : 'right']: `-${subListWidth}`,
+                }"
               >
-                <slot
-                  name="children-without-child"
-                  :item="item"
-                  :children="item.children"
-                />
-              </template>
-              <template v-else>
-                <div
-                  class="bimdata-menu__item__children"
-                  :style="getChildrenStyle(item)"
-                >
-                  <slot
-                    name="children-content"
-                    :item="item"
-                    :children="item.children"
+                <ul class="bimdata-list">
+                  <li
+                    v-for="child in item.children"
+                    :key="child.text"
+                    @click.stop="child.action && child.action()"
+                    class="flex items-center p-x-12"
                   >
-                    <ul :ref="`children-${item.key}`">
-                      <slot
-                        name="child-header"
-                        :item="item"
-                        :children="item.children"
-                      />
-                      <li
-                        v-for="child in item.children.list"
-                        :key="child.text"
-                        @click.stop="child.action && child.action()"
-                      >
-                        <slot name="child-item" :child="child" :item="item">
-                          <BIMDataTextbox :text="child.text" :tooltip="false" />
-                        </slot>
-                      </li>
-                      <slot
-                        name="child-footer"
-                        :item="item"
-                        :children="item.children"
-                      />
-                    </ul>
-                  </slot>
-                </div>
-              </template>
+                    <slot name="child-item" :child="child" :item="item">
+                      <BIMDataTextbox :text="child.text" :tooltip="false" />
+                    </slot>
+                  </li>
+                </ul>
+              </div>
             </template>
           </slot>
         </template>
-      </li>
+      </div>
       <template v-if="item.divider">
         <div class="divider"></div>
       </template>
-    </div>
+    </li>
   </ul>
 </template>
 
@@ -137,71 +114,39 @@ export default {
       type: String,
       default: "200px",
     },
-    isClickAway: {
-      type: Boolean,
-      default: true,
-    },
     childrenLeft: {
       type: Boolean,
       default: false,
     },
   },
-  emits: ["hover"],
   data() {
     return {
-      isItemHover: false,
-      currentItemKey: null,
-      displayed: false,
+      hoveredItemKey: null,
+      clickedItemKey: null,
     };
   },
   methods: {
-    getChildrenStyle(item) {
-      if (this.currentItemKey !== item.key) return { display: "none" };
-
-      const itemPos = this.$refs["item-" + item.key][0].getBoundingClientRect();
-      return {
-        width: this.subListWidth,
-        maxHeight: this.subListMaxHeight,
-        top: `${itemPos.top}px`,
-        left: `${
-          this.childrenLeft
-            ? itemPos.x -
-              parseInt(this.subListWidth.replace(/[a-zA-Z]/g, ""), 10)
-            : itemPos.x + itemPos.width
-        }px`,
-      };
-    },
-    handleCurrentItem(itemKey) {
-      if (itemKey) {
-        this.isItemHover = true;
-        this.currentItemKey = itemKey;
-      } else {
-        this.isItemHover = false;
-        this.currentItemKey = null;
-      }
-    },
-    onClick(item) {
-      if (this.hasNoChildren(item) || !item.action) return;
-      item.action();
-    },
-
-    onMouseOver(item) {
-      const itemPos = this.$refs["item-" + item.key][0].getBoundingClientRect();
-      this.handleCurrentItem(item.key);
-      this.$emit("hover", { ...item, itemPos });
-    },
-    onMouseLeave() {
-      this.handleCurrentItem();
-      this.$emit("hover");
-    },
-    hasNoChildren(item) {
-      const { children } = item;
-      return children && children.list.length === 0;
+    isItemActive(item) {
+      return (
+        (item.children?.length > 0 &&
+          this.hoveredItemKey === item.key &&
+          !this.clickedItemKey) ||
+        this.clickedItemKey === item.key
+      );
     },
     away() {
-      if (this.isClickAway) {
-        this.displayed = false;
+      this.clickedItemKey = null;
+    },
+    onItemClick(item) {
+      if (!item.children || item.key === this.clickedItemKey) {
+        this.clickedItemKey = null;
+      } else {
+        this.clickedItemKey = item.key;
       }
+    },
+    onMouseOver(item) {
+      this.hoveredItemKey = item.key;
+      this.$emit("hover", item);
     },
   },
 };

--- a/src/BIMDataComponents/BIMDataMenu/_BIMDataMenu.scss
+++ b/src/BIMDataComponents/BIMDataMenu/_BIMDataMenu.scss
@@ -2,7 +2,6 @@
   padding: var(--spacing-unit) 0;
   background-color: var(--color-white);
   box-shadow: var(--box-shadow);
-  overflow-y: auto;
   &__item {
     display: flex;
     flex-direction: column;
@@ -10,23 +9,26 @@
     justify-content: center;
     font-size: 12px;
     &:not(:empty) {
-      li {
+      .bimdata-menu__item__content {
         padding: 0 var(--spacing-unit);
         height: 29px;
         width: 100%;
         position: relative;
         display: flex;
         align-items: center;
+        cursor: pointer;
         & > span {
           width: 100%;
         }
         &:hover {
           background-color: var(--color-silver-light);
-          cursor: pointer;
+        }
+        &--active {
+          background-color: #f0f5ff;
         }
       }
     }
-    &--title {
+    &__title {
       padding: 0 var(--spacing-unit);
       height: 25px;
       display: flex;
@@ -35,33 +37,34 @@
       color: var(--color-granite);
       font-size: 11px;
     }
-    &--divider {
+    &__divider {
       .divider {
         margin: calc(var(--spacing-unit) / 2) auto;
         width: 90%;
         border-bottom: 1px solid #f2f2f2;
       }
     }
-    &--title,
-    &--divider {
+    &__title,
+    &__divider {
       &:hover {
         cursor: default;
         background-color: transparent;
       }
     }
-    &--no-children {
-      color: var(--color-silver-dark);
-    }
     &__children {
-      overflow: auto;
-      position: fixed;
+      position: absolute;
+      top: 0;
       padding: calc(var(--spacing-unit) / 2) 0;
       background-color: var(--color-white);
       border: 1px solid transparent;
       box-shadow: var(--box-shadow);
-
-      &--list {
-        padding-left: 0;
+      ul {
+        li {
+          height: 29px;
+          &:hover {
+            background-color: var(--color-silver-light);
+          }
+        }
       }
     }
   }

--- a/src/web/views/Components/Menu/BasicMenu.vue
+++ b/src/web/views/Components/Menu/BasicMenu.vue
@@ -19,6 +19,30 @@
               <BIMDataIcon :name="item.icon" size="xs" margin="0 6px 0 0" />
             </template>
             <span>{{ item.text }}</span>
+            <BIMDataIcon
+              v-if="item.children"
+              name="chevron"
+              size="xxs"
+              margin="0 0 0 auto"
+            />
+          </template>
+          <template #child-item="{ item }">
+            <div v-if="item.children[0].data">
+              <span
+                v-for="child in item.children"
+                :key="child.id"
+                class="color-high"
+              >
+                <BIMDataIcon
+                  name="warning"
+                  size="xxs"
+                  margin="0 6px 0 0"
+                  fill
+                  color="high"
+                />
+                {{ child.data }}
+              </span>
+            </div>
           </template>
         </BIMDataMenu>
       </template>
@@ -95,15 +119,17 @@ export default {
       if (this.isChildren) {
         opts[1] = {
           ...opts[1],
-          children: {
-            list: [
-              {
-                text: "Child item 1",
-                action: () => console.log("child clicked"),
-              },
-              { text: "Child item 2" },
-            ],
-          },
+          children: [
+            {
+              text: "Child item 1",
+              action: () => console.log("child clicked"),
+            },
+            { text: "Child item 2" },
+          ],
+        };
+        opts[2] = {
+          ...opts[2],
+          children: [{ data: "Item 03 children" }],
         };
       }
       return opts;

--- a/src/web/views/Components/Menu/BasicMenu.vue
+++ b/src/web/views/Components/Menu/BasicMenu.vue
@@ -63,11 +63,13 @@
                   {{ formatMenuItem(item) }},</template>
               ]"
               @item-click="itemClick"
+              :childrenLeft="{{isChildrenLeft}}"
             &gt;
             &lt;template #item="{ item }"&gt;
               {{ getIcons() }}
               &lt;span&gt;{{ "{{ item.text }" + "}" }}&lt;/span&gt;
             &lt;/template&gt;
+            {{getChildren()}}
           &lt;/BIMDataMenu&gt;
         </pre>
       </template>
@@ -144,6 +146,30 @@ export default {
                 size="xs"
                 margin="0 6px 0 0"
               />`;
+      }
+    },
+    getChildren() {
+      if (this.isChildren) {
+        return `
+        <template #child-item="{ item }">
+          <div v-if="item.children[0].data">
+            <span
+              v-for="child in item.children"
+              :key="child.id"
+              class="color-high"
+            >
+              <BIMDataIcon
+                name="warning"
+                size="xxs"
+                margin="0 6px 0 0"
+                fill
+                color="high"
+              />
+              {{ child.data }}
+            </span>
+          </div>
+        </template>
+      `;
       }
     },
     itemClick($event) {

--- a/src/web/views/Components/Menu/props-basic-menu.js
+++ b/src/web/views/Components/Menu/props-basic-menu.js
@@ -28,12 +28,6 @@ export default [
     "Use this props to custom width of BIMDataMenu component.",
   ],
   [
-    "isClickAway",
-    "Boolean",
-    "true",
-    "If false, the menu component does not close when you click outside.",
-  ],
-  [
     "childrenLeft",
     "Boolean",
     "false",

--- a/src/web/views/Components/Menu/slots-basic-menu.js
+++ b/src/web/views/Components/Menu/slots-basic-menu.js
@@ -2,9 +2,6 @@ export default [
   ["Slot name", "Description"],
   ["groupTitle", "Use this slot for custom group title."],
   ["item", "Use this slot for custom items menu."],
-  ["children-content", "Use this slot for custom children of menu items."],
-  // ["children", "Use this slot for custom children of menu items."],
-  // ["child-header", "Use this slot for custom child header."],
+  ["children", "Use this slot for custom children of menu items."],
   ["child-item", "Use this slot for custom list elements of child items."],
-  // ["child-footer", "Use this slot for custom child footer."],
 ];


### PR DESCRIPTION
Delete complex logical in BIMDataMenu only  used for `GroupImport` in platform.
Delete some slots (used sometimes but not necessary )

- [x] I have tested my component
- [x] I have updated the documentation or there is no documentation needed
