### PR TITLE
add disabled props for BIMDataSearch component & doc

### DIFF
--- a/src/BIMDataComponents/BIMDataSearch/BIMDataSearch.vue
+++ b/src/BIMDataComponents/BIMDataSearch/BIMDataSearch.vue
@@ -3,7 +3,7 @@
     class="bimdata-search-bar"
     v-clickaway="away"
     :style="{ width: width, height: height }"
-    :class="{ focus: focused, ...classes }"
+    :class="{ focus: focused, disabled, ...classes }"
   >
     <span class="bimdata-search-icon">
       <BIMDataIconSearch size="xxs" />
@@ -18,6 +18,7 @@
       :placeholder="placeholder"
       @keyup.enter="$emit('enter', $event.target.value)"
       :autocomplete="autocomplete ? 'on' : 'off'"
+      :disabled="disabled"
     />
     <BIMDataButton
       width="25px"
@@ -96,6 +97,10 @@ export default {
       validator: color => colors.includes(color),
     },
     autocomplete: {
+      type: Boolean,
+      default: false,
+    },
+    disabled: {
       type: Boolean,
       default: false,
     },

--- a/src/BIMDataComponents/BIMDataSearch/_BIMDataSearch.scss
+++ b/src/BIMDataComponents/BIMDataSearch/_BIMDataSearch.scss
@@ -28,6 +28,12 @@
     box-shadow: var(--box-shadow);
     transition: all 0.2s ease;
   }
+  &.disabled {
+    color: var(--color-silver);
+    input {
+      color: var(--color-silver);
+    }
+  }
 
   &__radius {
     border-radius: 3px;

--- a/src/web/views/Components/Search/Search.vue
+++ b/src/web/views/Components/Search/Search.vue
@@ -17,6 +17,7 @@
             :clear="isClear"
             :width="width + 'px'"
             :height="height + 'px'"
+            :disabled="isDisabled"
           />
         </template>
 
@@ -40,6 +41,7 @@
             v-model="placeholder"
           />
           <BIMDataCheckbox text="clear" v-model="isClear" />
+          <BIMDataCheckbox text="disabled" v-model="isDisabled" />
           <div
             v-for="[key, values] in Object.entries(searchOptions)"
             :key="key"
@@ -75,6 +77,7 @@
               color="{{ selectedSearchOptionsstyle }}"
               {{ selectedSearchOptionskinds }}
               clear="{{ isClear }}"
+              disabled="{{ isDisabled }}"
               :width="{{ width + "px" }}"
               :height="{{ height + "px" }}"
             /&gt;
@@ -115,6 +118,7 @@ export default {
       backgroundColor: false,
       placeholder: "Search",
       isClear: false,
+      isDisabled: false,
       width: 150,
       height: 32,
       selectedSearchOptionskinds: "radius",

--- a/src/web/views/Components/Search/props-data.js
+++ b/src/web/views/Components/Search/props-data.js
@@ -2,6 +2,42 @@
 export default [
   [ "Props", "Type", "Default value", "Description" ],
   [
+    "autocomplete",
+    "Boolean",
+    "false",
+    "Whether 'autocomplete' attribute is 'on' or 'off'."
+  ],
+  [
+    "autofocus",
+    "Boolean",
+    "false",
+    "Use this boolean to add an autofocus on the input search",
+  ],
+  [
+    "clear",
+    "Boolean",
+    "false",
+    "Use this prop to add a button that delete text in search bar",
+  ],
+  [
+    "color",
+    "String",
+    "default",
+    "Use this prop to select search bar color: 'default', 'primary', 'secondary'",
+  ],
+  [
+    "disabled",
+    "Boolean",
+    "false",
+    "Use this boolean to disabled your input.",
+  ],
+  [
+    "height",
+    "[Number, String]",
+    "32px",
+    "Use this props to change the height of the search component",
+  ],
+  [
     "modelValue",
     "String",
     "",
@@ -12,30 +48,6 @@ export default [
     "String",
     "' '",
     "Use this props to add a placeholder.",
-  ],
-  [
-    "autocomplete",
-    "Boolean",
-    "false",
-    "Whether 'autocomplete' attribute is 'on' or 'off'."
-  ],
-  [
-    "width",
-    "[Number, String]",
-    "150px",
-    "Use this props to change the width of the search component",
-  ],
-  [
-    "height",
-    "[Number, String]",
-    "32px",
-    "Use this props to change the height of the search component",
-  ],
-  [
-    "autofocus",
-    "Boolean",
-    "false",
-    "Use this boolean to add an autofocus on the input search",
   ],
   [
     "radius",
@@ -50,15 +62,9 @@ export default [
     "Use this prop to use square search bar",
   ],
   [
-    "color",
-    "String",
-    "default",
-    "Use this prop to select search bar color: 'default', 'primary', 'secondary'",
-  ],  
-  [
-    "clear",
-    "Boolean",
-    "false",
-    "Use this prop to add a button that delete text in search bar",
+    "width",
+    "[Number, String]",
+    "150px",
+    "Use this props to change the width of the search component",
   ],
 ];


### PR DESCRIPTION
- [x] I have tested my component
- [x] I have updated the documentation or there is no documentation needed

## Libraries that use the DS (need to merge first)

- [ ] [BCF Components](https://github.com/bimdata/bcf-components)
- [ ] [BIMData Components](https://github.com/bimdata/bimdata-components)
- [ ] [Building maker](https://github.com/bimdata/building-maker)

## Repos that use the DS (and that I need to check after libraries have been merged)

- [ ] [Viewer](https://github.com/bimdata/viewer)
- [ ] [Platform](https://github.com/bimdata/platform)
- [ ] [SDK](https://github.com/bimdata/bimdata-viewer-sdk)
- [ ] [Marketplace](https://github.com/bimdata/marketplace-front)
- [ ] [Documentation](https://github.com/bimdata/documentation)
