### PR TITLE
PATCH: Feature: Add 'dragAndDrop' prop to BIMDataTree

### DIFF
--- a/src/BIMDataComponents/BIMDataTree/BIMDataTree.vue
+++ b/src/BIMDataComponents/BIMDataTree/BIMDataTree.vue
@@ -7,7 +7,12 @@
     @mouseup.self="onMouseUp"
   >
     <div class="bimdata-tree__nodes" @mouseleave="onNodesMouseLeave">
-      <Node v-for="node of data" :key="node.id" :node="node">
+      <Node
+        v-for="node of data"
+        :key="node.id"
+        :node="node"
+        :drag-and-drop="dragAndDrop"
+      >
         <slot
           name="node"
           :node="node"
@@ -73,6 +78,10 @@ export default {
       type: Number,
       default: null,
     },
+    dragAndDrop: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: ["drop", "click", "hover"],
   setup(props, { emit }) {
@@ -95,7 +104,10 @@ export default {
 
     const dropHelperDisplayed = computed(
       () =>
-        hover.value && state.dragPosition !== null && state.hoveredNode === null
+        props.dragAndDrop &&
+        hover.value &&
+        state.dragPosition !== null &&
+        state.hoveredNode === null
     );
 
     return {

--- a/src/BIMDataComponents/BIMDataTree/Node.vue
+++ b/src/BIMDataComponents/BIMDataTree/Node.vue
@@ -44,6 +44,7 @@
     v-if="node.children?.length > 0 && expanded"
     :node="node"
     :depth="depth + 1"
+    :drag-and-drop="dragAndDrop"
   />
 </template>
 
@@ -64,20 +65,25 @@ NodeChildren = {
       type: Number,
       default: 0,
     },
+    dragAndDrop: {
+      type: Boolean,
+      default: false,
+    },
   },
   render() {
-    const { node, depth, root } = this;
+    const { node, depth, dragAndDrop, root } = this;
 
     const state = root.state;
 
     return node.children.map(child =>
-      h(Node, { node: child, depth, key: child.id }, () =>
+      h(Node, { node: child, depth, dragAndDrop, key: child.id }, () =>
         root.$slots.node?.({
           node: child,
           depth,
           selected: child.id === state.selectedId,
           hovered: child.id === state.hoveredNode?.id,
           ancestorSelected: state.hasAncestorSelected(child),
+          dragAndDrop,
         })
       )
     );
@@ -98,6 +104,10 @@ Node = {
     depth: {
       type: Number,
       default: 0,
+    },
+    dragAndDrop: {
+      type: Boolean,
+      default: false,
     },
   },
   setup(props) {
@@ -154,7 +164,11 @@ Node = {
     };
 
     const dropHelperPosition = computed(() => {
-      if (!state.dragPosition || state.hoveredNode?.id !== props.node.id)
+      if (
+        !props.dragAndDrop ||
+        !state.dragPosition ||
+        state.hoveredNode?.id !== props.node.id
+      )
         return null;
 
       return state.getNodeDropPosition(props.node, nodeRef.value);

--- a/src/BIMDataComponents/BIMDataTree/state.js
+++ b/src/BIMDataComponents/BIMDataTree/state.js
@@ -62,7 +62,7 @@ export default function useState(props, emit) {
     state.dragPosition = { x: clientX, y: clientY };
   };
   const onNodeMouseUp = (node, domElement, expanded) => {
-    if (!state.dragPosition) return;
+    if (!props.dragAndDrop || !state.dragPosition) return;
 
     if (state.hoveredNode?.id === pressedNode.value?.id) return;
 
@@ -131,7 +131,7 @@ export default function useState(props, emit) {
     emit("click", null);
   };
   const onTreeMouseUp = () => {
-    if (!state.dragPosition) return;
+    if (!props.dragAndDrop || !state.dragPosition) return;
 
     if (state.trees.indexOf(pressedNode.value) === state.trees.length - 1) {
       // to drop the last root node at the end of the list does not fire the drop event


### PR DESCRIPTION
 - PATCH: feat(bimdata-tree): add dragAndDrop prop to enable/disable drag and drop feature

- [x] I have tested my component
- [ ] I have updated the documentation or there is no documentation needed

## Libraries that use the DS (need to merge first)

- [ ] [BCF Components](https://github.com/bimdata/bcf-components)
- [ ] [BIMData Components](https://github.com/bimdata/bimdata-components)
- [ ] [Building maker](https://github.com/bimdata/building-maker)

## Repos that use the DS (and that I need to check after libraries have been merged)

- [ ] [Viewer](https://github.com/bimdata/viewer)
- [ ] [Platform](https://github.com/bimdata/platform)
- [ ] [SDK](https://github.com/bimdata/bimdata-viewer-sdk)
- [ ] [Marketplace](https://github.com/bimdata/marketplace-front)
- [ ] [Documentation](https://github.com/bimdata/documentation)
