### PR TITLE
PATCH: fix(tree): allow node.id to be a string

### DIFF
--- a/src/BIMDataComponents/BIMDataTree/BIMDataTree.vue
+++ b/src/BIMDataComponents/BIMDataTree/BIMDataTree.vue
@@ -62,7 +62,7 @@ export default {
         const ids = new Set();
 
         for (const node of value) {
-          if (!Number.isFinite(node?.id)) return false;
+          if (!Number.isFinite(node?.id) && typeof node?.id !== "string") return false;
           if (node.children && !Array.isArray(node.children)) return false;
           ids.add(node.id);
         }

--- a/src/BIMDataComponents/BIMDataTree/Node.vue
+++ b/src/BIMDataComponents/BIMDataTree/Node.vue
@@ -60,7 +60,7 @@ NodeChildren = {
     node: {
       type: Object,
       required: true,
-      validator: node => Number.isFinite(node?.id),
+      validator: node => (Number.isFinite(node?.id) || typeof node?.id === "string"),
     },
     depth: {
       type: Number,


### PR DESCRIPTION
- [ ] I have tested my component
- [ ] I have updated the documentation or there is no documentation needed

## Libraries that use the DS (need to merge first)

- [ ] [BCF Components](https://github.com/bimdata/bcf-components)
- [ ] [BIMData Components](https://github.com/bimdata/bimdata-components)
- [ ] [Building maker](https://github.com/bimdata/building-maker)

## Repos that use the DS (and that I need to check after libraries have been merged)

- [ ] [Viewer](https://github.com/bimdata/viewer)
- [ ] [Platform](https://github.com/bimdata/platform)
- [ ] [SDK](https://github.com/bimdata/bimdata-viewer-sdk)
- [ ] [Marketplace](https://github.com/bimdata/marketplace-front)
- [ ] [Documentation](https://github.com/bimdata/documentation)
