### PR TITLE
add quaternary-lighter to props button & color standardization & docu…

### DIFF
--- a/src/BIMDataComponents/BIMDataButton/BIMDataButton.css
+++ b/src/BIMDataComponents/BIMDataButton/BIMDataButton.css
@@ -83,6 +83,13 @@
         background-color: var(--color-quaternary-light);
       }
     }
+    &.quaternary-lighter {
+      background-color: var(--color-quaternary-lighter);
+      color: var(--color-quaternary);
+      &:hover {
+        background-color: color-mix(in srgb, transparent, var(--color-quaternary-lighter) 90%);
+      }
+    }
     /* style BIMDATA BTN GREY FILL ------------- */
     &.granite {
       background-color: var(--color-granite);
@@ -353,16 +360,16 @@
     &.default {
       border-color: var(--color-tertiary-lighter);
       color: var(--color-primary);
-      /* &:hover {
-        background-color: var(--color-silver-light);
-      } */
+      &:hover {
+        background-color: color-mix(in srgb, transparent, var(--color-primary) 5%);
+      }
     }
     &.light-default {
       border-color: var(--color-tertiary-lighter);
       color: var(--color-tertiary);
-      /* &:hover {
-        background-color: var(--color-silver-light);
-      } */
+      &:hover {
+        background-color: color-mix(in srgb, transparent, var(--color-tertiary) 5%);
+      }
     }
     &.primary {
       border-color: var(--color-primary);
@@ -389,7 +396,14 @@
       border-color: var(--color-quaternary);
       color: var(--color-quaternary);
       &:hover {
-        background-color: var(--color-quaternary-lighter);
+        background-color: color-mix(in srgb, transparent, var(--color-quaternary-lighter) 10%);
+      }
+    }
+    &.quaternary-lighter {
+      border-color: var(--color-quaternary-lighter);
+      color: var(--color-quaternary-lighter);
+      &:hover {
+        background-color: color-mix(in srgb, transparent, var(--color-quaternary-lighter) 10%);
       }
     }
     &.granite {
@@ -483,9 +497,15 @@
       }
     }
     &.quaternary {
+      color: var(--color-quaternary);
+      &:hover {
+        background-color: color-mix(in srgb, transparent, var(--color-quaternary-lighter) 10%);
+      }
+    }
+    &.quaternary-lighter {
       color: var(--color-quaternary-lighter);
       &:hover {
-        background-color: var(--color-quaternary-dark);
+        background-color: color-mix(in srgb, transparent, var(--color-quaternary-lighter) 10%);
       }
     }
     &.granite {

--- a/src/assets/colors.js
+++ b/src/assets/colors.js
@@ -5,6 +5,7 @@ export default Object.freeze([
   "secondary",
   "tertiary",
   "quaternary",
+  "quaternary-lighter",
   "granite",
   "silver",
   "high",

--- a/src/web/views/Components/Buttons/props-data.js
+++ b/src/web/views/Components/Buttons/props-data.js
@@ -6,7 +6,7 @@ export default [
     "String",
     "true",
     "",
-    "Use this props to change the color of the button. Values can be 'default', 'primary',  'secondary', 'tertiary', 'success', 'warning', 'high', 'info', 'granite'",
+    "Use this props to change the color of the button. Values can be : 'default', 'light-default', 'primary',  'secondary', 'tertiary', 'quaternary', 'quaternary-lighter', 'success', 'warning', 'high', 'info', 'granite', 'silver', 'white'",
   ],
   [
     "fill",


### PR DESCRIPTION
add quaternary-lighter to props button & color standardization & documentation

- [x] I have tested my component
- [x] I have updated the documentation or there is no documentation needed

## Libraries that use the DS (need to merge first)

- [ ] [BCF Components](https://github.com/bimdata/bcf-components)
- [ ] [BIMData Components](https://github.com/bimdata/bimdata-components)
- [ ] [Building maker](https://github.com/bimdata/building-maker)

## Repos that use the DS (and that I need to check after libraries have been merged)

- [ ] [Viewer](https://github.com/bimdata/viewer)
- [ ] [Platform](https://github.com/bimdata/platform)
- [ ] [SDK](https://github.com/bimdata/bimdata-viewer-sdk)
- [ ] [Marketplace](https://github.com/bimdata/marketplace-front)
- [ ] [Documentation](https://github.com/bimdata/documentation)
