### PR TITLE
add dark props for BIMDataSafeZoneInline component

### DIFF
--- a/src/BIMDataComponents/BIMDataSafeZoneInline/BIMDataSafeZoneInline.css
+++ b/src/BIMDataComponents/BIMDataSafeZoneInline/BIMDataSafeZoneInline.css
@@ -13,4 +13,9 @@
   & .safe-zone-inline__btn-close {
     padding: 0 8px;
   }
+
+  &.dark {
+    background-color: var(--color-quaternary);
+    color: var(--color-quaternary-lighter);
+  }
 }

--- a/src/BIMDataComponents/BIMDataSafeZoneInline/BIMDataSafeZoneInline.vue
+++ b/src/BIMDataComponents/BIMDataSafeZoneInline/BIMDataSafeZoneInline.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="safe-zone-inline">
+  <div class="safe-zone-inline" :class="{ dark: isDark }">
     <BIMDataButton
       class="safe-zone-inline__btn-delete"
       color="high"
@@ -14,9 +14,10 @@
       :style="{ width: '15px', order: reverse ? -1 : 0 }"
       width="0px"
       radius
+      :color="isDark ? 'quaternary' : 'granite'"
       @click="$emit('cancel-delete')"
     >
-      <BIMDataIconClose size="xxs" color="granite" />
+      <BIMDataIconClose size="xxs" :color="isDark ? 'quaternary-lighter' : 'granite'" />
     </BIMDataButton>
   </div>
 </template>
@@ -30,6 +31,12 @@ export default {
     BIMDataIconClose,
     BIMDataButton,
   },
+  inject: {
+    darkThemeRef: {
+      from: "BIMDATA_DESIGN_SYSTEM_DARK_THEME",
+      default: () => ({ value: false }),
+    },
+  },
   props: {
     reverse: {
       type: Boolean,
@@ -37,6 +44,11 @@ export default {
     },
   },
   emits: ["confirm-delete", "cancel-delete"],
+  computed: {
+    isDark() {
+      return this.darkThemeRef;
+    },
+  }
 };
 </script>
 


### PR DESCRIPTION
- [ ] I have tested my component
- [ ] I have updated the documentation or there is no documentation needed

## Libraries that use the DS (need to merge first)

- [ ] [BCF Components](https://github.com/bimdata/bcf-components)
- [ ] [BIMData Components](https://github.com/bimdata/bimdata-components)
- [ ] [Building maker](https://github.com/bimdata/building-maker)

## Repos that use the DS (and that I need to check after libraries have been merged)

- [ ] [Viewer](https://github.com/bimdata/viewer)
- [ ] [Platform](https://github.com/bimdata/platform)
- [ ] [SDK](https://github.com/bimdata/bimdata-viewer-sdk)
- [ ] [Marketplace](https://github.com/bimdata/marketplace-front)
- [ ] [Documentation](https://github.com/bimdata/documentation)
