### PR TITLE
add fill & stroke colors for tertiary, quaternary and quaternary-lighter

### DIFF
--- a/src/BIMDataComponents/BIMDataIcon/BIMDataIcon.css
+++ b/src/BIMDataComponents/BIMDataIcon/BIMDataIcon.css
@@ -21,6 +21,15 @@
     &.icon-fill--secondary {
       fill: var(--color-secondary);
     }
+    &.icon-fill--tertiary {
+      fill: var(--color-tertiary);
+    }
+    &.icon-fill--quaternary {
+      fill: var(--color-quaternary);
+    }
+    &.icon-fill--quaternary-lighter {
+      fill: var(--color-quaternary-lighter);
+    }
     &.icon-fill--success {
       fill: var(--color-success);
     }
@@ -68,6 +77,15 @@
     }
     &.icon-stroke--secondary {
       stroke: var(--color-secondary);
+    }
+    &.icon-stroke--tertiary {
+      stroke: var(--color-tertiary);
+    }
+    &.icon-stroke--quaternary {
+      stroke: var(--color-quaternary);
+    }
+    &.icon-stroke--quaternary-lighter {
+      stroke: var(--color-quaternary-lighter);
     }
     &.icon-stroke--success {
       stroke: var(--color-success);

--- a/src/assets/colors.js
+++ b/src/assets/colors.js
@@ -5,6 +5,7 @@ export default Object.freeze([
   "secondary",
   "tertiary",
   "quaternary",
+  "quaternary-light",
   "quaternary-lighter",
   "granite",
   "silver",


### PR DESCRIPTION
- [x] I have tested my component
- [ ] I have updated the documentation or there is no documentation needed

## Libraries that use the DS (need to merge first)

- [ ] [BCF Components](https://github.com/bimdata/bcf-components)
- [ ] [BIMData Components](https://github.com/bimdata/bimdata-components)
- [ ] [Building maker](https://github.com/bimdata/building-maker)

## Repos that use the DS (and that I need to check after libraries have been merged)

- [ ] [Viewer](https://github.com/bimdata/viewer)
- [ ] [Platform](https://github.com/bimdata/platform)
- [ ] [SDK](https://github.com/bimdata/bimdata-viewer-sdk)
- [ ] [Marketplace](https://github.com/bimdata/marketplace-front)
- [ ] [Documentation](https://github.com/bimdata/documentation)
