### PR TITLE
add quaternary-light option to search & select components

### DIFF
--- a/src/BIMDataComponents/BIMDataSearch/BIMDataSearch.css
+++ b/src/BIMDataComponents/BIMDataSearch/BIMDataSearch.css
@@ -23,8 +23,6 @@
   }
   &.focus {
     background-color: var(--color-white);
-    /* box-shadow: var(--box-shadow);
-    transition: all 0.2s ease; */
   }
   &.disabled {
     color: var(--color-silver);
@@ -48,6 +46,7 @@
   }
   &.bimdata-search-bar__primary {
     background-color: var(--color-silver-light);
+    color: var(--color-primary);
   }
   &.bimdata-search-bar__secondary {
     background-color: var(--color-white);
@@ -57,6 +56,16 @@
   }
   &.bimdata-search-bar__quaternary {
     background-color: var(--color-quaternary);
+    color: var(--color-quaternary-lighter);
+    input {
+      color: var(--color-quaternary-lighter);
+      &::placeholder{
+        color: var(--color-quaternary-lighter);
+      }
+    }
+  }
+  &.bimdata-search-bar__quaternary-light {
+    background-color: var(--color-quaternary-light);
     color: var(--color-quaternary-lighter);
     input {
       color: var(--color-quaternary-lighter);

--- a/src/BIMDataComponents/BIMDataSelect/BIMDataSelectMulti.vue
+++ b/src/BIMDataComponents/BIMDataSelect/BIMDataSelectMulti.vue
@@ -131,7 +131,7 @@ export default {
       type: String,
       default: "primary",
       validator: value =>
-        ["primary", "secondary", "tertiary", "quaternary"].includes(value),
+        ["primary", "secondary", "tertiary", "quaternary", "quaternary-light"].includes(value),
     },
     searchPlaceholder: {
       type: String,

--- a/src/BIMDataComponents/BIMDataSelect/BIMDataSelectSingle.vue
+++ b/src/BIMDataComponents/BIMDataSelect/BIMDataSelectSingle.vue
@@ -142,7 +142,7 @@ export default {
       type: String,
       default: "primary",
       validator: value =>
-        ["primary", "secondary", "tertiary", "quaternary"].includes(value),
+        ["primary", "secondary", "tertiary", "quaternary", "quaternary-light"].includes(value),
     },
   },
   emits: ["update:modelValue"],

--- a/src/web/views/Components/Search/Search.vue
+++ b/src/web/views/Components/Search/Search.vue
@@ -140,7 +140,7 @@ export default {
       selectedSearchOptionsstyle: "primary",
       searchOptions: {
         kinds: ["radius", "square"],
-        style: ["primary", "secondary", "tertiary", "quaternary"],
+        style: ["primary", "secondary", "tertiary", "quaternary", "quaternary-light"],
       },
       propsData,
       eventsData,
@@ -167,16 +167,3 @@ export default {
   },
 };
 </script>
-
-<style scoped>
-.theme-dark {
-  .article-search {
-    .bimdata-search-bar {
-      color: var(--color-primary);
-      &.bimdata-search-bar__quaternary {
-        color: var(--color-quaternary-lighter);
-      }
-    }
-  }
-}
-</style>

--- a/src/web/views/Components/Select/Select.vue
+++ b/src/web/views/Components/Select/Select.vue
@@ -137,8 +137,14 @@
               {{ optionLabelKey ? `optionLabelKey="${optionLabelKey}"` : "" }}
               {{ hasNullValue ? ':nullValue="true"' : "" }}
               v-model="selection"
-              {{ selectedOptionsColor ? `color="${selectedOptionsColor}"` : "" }}
-              {{ selectedSearchColor && search ? `searchColor="${selectedSearchColor}"` : "" }}
+              {{
+              selectedOptionsColor ? `color="${selectedOptionsColor}"` : ""
+            }}
+              {{
+              selectedSearchColor && search
+                ? `searchColor="${selectedSearchColor}"`
+                : ""
+            }}
             &gt;
             {{ getEmptySlot() }}
               
@@ -262,7 +268,7 @@ export default {
             "tertiary",
             "tertiary-light",
             "quaternary",
-            "white"
+            "white",
           ],
           model: "selectedOptionsColor",
         },
@@ -273,6 +279,7 @@ export default {
             "secondary",
             "tertiary",
             "quaternary",
+            "quaternary-light",
           ],
           model: "selectedSearchColor",
         },


### PR DESCRIPTION
- [x] I have tested my component
- [x] I have updated the documentation or there is no documentation needed

## Libraries that use the DS (need to merge first)

- [ ] [BCF Components](https://github.com/bimdata/bcf-components)
- [ ] [BIMData Components](https://github.com/bimdata/bimdata-components)
- [ ] [Building maker](https://github.com/bimdata/building-maker)

## Repos that use the DS (and that I need to check after libraries have been merged)

- [ ] [Viewer](https://github.com/bimdata/viewer)
- [ ] [Platform](https://github.com/bimdata/platform)
- [ ] [SDK](https://github.com/bimdata/bimdata-viewer-sdk)
- [ ] [Marketplace](https://github.com/bimdata/marketplace-front)
- [ ] [Documentation](https://github.com/bimdata/documentation)
